### PR TITLE
use fakeroot to pack the files with ownership set to root/root

### DIFF
--- a/build/deb_package.py
+++ b/build/deb_package.py
@@ -56,7 +56,7 @@ shutil.copy(os.path.join(top_dir, "install", "debian_prerm"), \
             os.path.join(product_dir, "deb", "debian", "tmp", "DEBIAN", "prerm"))
 
 # Create .deb file
-args = ['dpkg-deb', '-z9', '-Zxz', '-b']
+args = ['fakeroot', 'dpkg-deb', '-z9', '-Zxz', '-b']
 args.append(os.path.join(product_dir, "deb", "debian", "tmp"))
 args.append(os.path.join(product_dir, package_name + '.deb'))
 subprocess.Popen(args).wait()


### PR DESCRIPTION
From man:

> fakeroot was specifically written to enable users to create Debian GNU/Linux packages  (in  the  deb(5) format)  without  giving  them  root  privileges.
