### PR TITLE
fix build under ubuntu 14.04

### DIFF
--- a/build/configure
+++ b/build/configure
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 gn_path=`dirname $0`/../bin
 if [[ `uname` == 'Linux' ]]; then

--- a/src/client/BUILD.gn
+++ b/src/client/BUILD.gn
@@ -10,6 +10,8 @@ executable("clang") {
     ":config_proto",
     "//src/base:base",
     "//src/base:logging",
+    "//src/perf:stat_service",
+    "//src/perf:counter",
   ]
 }
 

--- a/src/daemon/BUILD.gn
+++ b/src/daemon/BUILD.gn
@@ -39,6 +39,7 @@ source_set("daemon") {
     "//src/net:net",
     "//src/perf:counter",
     "//src/perf:stat_service",
+    "//src/third_party/snappy:snappy",
   ]
 }
 


### PR DESCRIPTION
build/configure contains bash specific `[[` syntax (not sh)

clangd and clang++ missing some deps (not sure if that's correct way to fix)

I am metaflow@ yandex