### PR TITLE
Issue 29, check for bad client version

### DIFF
--- a/src/daemon/absorber.h
+++ b/src/daemon/absorber.h
@@ -9,6 +9,8 @@ namespace daemon {
 
 class Absorber : public CompilationDaemon {
  public:
+  static const ui32 kMinGoodClientVersion;
+
   explicit Absorber(const proto::Configuration& configuration);
   virtual ~Absorber();
 

--- a/src/daemon/remote.proto
+++ b/src/daemon/remote.proto
@@ -7,6 +7,7 @@ package dist_clang.daemon.proto;
 message Remote {
   optional base.proto.Flags flags = 1;
   optional string source          = 2;
+  optional uint32 client_version  = 3 [ default = 100 ];
 
   extend net.proto.Universal {
     optional Remote extension = 6;

--- a/src/net/universal.proto
+++ b/src/net/universal.proto
@@ -17,6 +17,7 @@ message Status {
     EXECUTION     = 5;
     OVERLOAD      = 6;
     NO_VERSION    = 7;
+    BAD_CLIENT_VERSION = 8;
   }
 
   required Code code           = 1 [ default = OK ];


### PR DESCRIPTION
Hi!

Here is my initial version of client version validation (#29), so we can discuss this approach.
Constant 100 for version is a sample only.
Should we expose that minimal version value to C++ code and keep it sync with the default value in proto file?
Please, take a look.