### PR TITLE
Added begin/end transaction calls to FileCache::Clean.

### DIFF
--- a/src/cache/file_cache.cc
+++ b/src/cache/file_cache.cc
@@ -487,6 +487,7 @@ void FileCache::DoStore(UnhandledHash orig_hash, const List<String>& headers,
 }
 
 void FileCache::Clean(UniquePtr<EntryList> list) {
+  entries_->BeginTransaction();
   while (auto new_entry = list->Pop()) {
     const auto& hash = new_entry->second;
     SQLite::Value entry;
@@ -511,6 +512,7 @@ void FileCache::Clean(UniquePtr<EntryList> list) {
   }
 
   if (max_size_ == UNLIMITED) {
+    entries_->EndTransaction();
     return;
   }
 
@@ -527,6 +529,7 @@ void FileCache::Clean(UniquePtr<EntryList> list) {
       DCHECK_O_EVAL(RemoveEntry(hash));
     }
   }
+  entries_->EndTransaction();
 }
 
 FileCache::ReadLock::ReadLock(const FileCache* file_cache, const String& path)


### PR DESCRIPTION
This transactions help to speed up processing of SQLite database when it resides on disk: instead of committing each update as a separate transaction, we make a batch of them and commit in a single step.

I performed the following test:

1. Take a cache with roughly 600 items, start `clangd` on it.
2. Touch half of the items with cache hit.
3. Shutdown `clangd` with `SIGTERM` before regular cleanup thread wakes up.
4. Wait for the daemon to exit.

I was using virtual machine with 4 cores and HDD. Results are the following:

— When using current version with `store_index: true` the daemon exits in about 120 seconds after receiving the signal, actively using the disk in the meantime.
— When using `store_index: false` the deamon exits almost instantly, in about a second (the binary includes a patch to exit early which I implemented in https://github.com/abyss7/dist-clang/pull/59)
— When using modified version and `store_index: true` the daemon exits in about a couple of seconds after receiving the signal.