### PR TITLE
Enhance thread pool test and make it more strict.

### DIFF
--- a/src/base/thread_pool_test.cc
+++ b/src/base/thread_pool_test.cc
@@ -17,7 +17,7 @@ TEST(ThreadPoolTest, CompleteAllTasksOnDestruction) {
 
   UniqueLock lock(mutex);
 
-  std::vector<ThreadPool::Optional> futures;
+  Vector<ThreadPool::Optional> futures;
   for (size_t i = 0; i != expected_count; ++i) {
     futures.emplace_back(pool->Push([&] {
       UniqueLock lock(mutex);

--- a/src/base/thread_pool_test.cc
+++ b/src/base/thread_pool_test.cc
@@ -8,7 +8,7 @@ namespace base {
 TEST(ThreadPoolTest, CompleteAllTasksOnDestruction) {
   Mutex mutex;
   std::condition_variable condition;
-  bool ready = false;
+  Atomic<bool> ready(false);
 
   const size_t expected_count = 200;
   Atomic<size_t> done = {0};
@@ -21,7 +21,7 @@ TEST(ThreadPoolTest, CompleteAllTasksOnDestruction) {
   for (size_t i = 0; i != expected_count; ++i) {
     futures.emplace_back(pool->Push([&] {
       UniqueLock lock(mutex);
-      condition.wait(lock, [&ready] { return ready; });
+      condition.wait(lock, [&ready] () -> bool { return ready; });
       ++done;
       condition.notify_all();
     }));


### PR DESCRIPTION
Original test probably tests almost nothing: test thread is actually externally synchronised with the thread from thread pool via `ready` and `done` variables: test thread does not continue execution until pooled thread sets `done` to `true` (waiting for one second, which is a huge delay, given that actually it takes less than one millisecond).

For example, we could initialise `WorkerPool` instance with `force_shut_down = true` in `ThreadPool` constructor, which actually brakes the test invariant, and the test would have never noticed that.

New version pushes a bunch of tasks to the queue, so that there would be not enough threads to complete all of them instantly, and then launches the destruction thread, which now really competes with workers. So now we detect broken invariant easily: if we misuse worker pool and force it to shutdown, the queue will have some tasks left and the threads will exit before completing all the tasks.