### PR TITLE
Fix racey ProcessTest.

### DIFF
--- a/src/base/process_test.cc
+++ b/src/base/process_test.cc
@@ -125,13 +125,13 @@ TEST_F(ProcessTest, DISABLED_WaitPidWithTimeOut) {
 
 TEST_F(ProcessTest, ProcessAborts) {
   ProcessPtr process = Process::Create(sh, String(), Process::SAME_UID);
-  process->AppendArg("-c"_l).AppendArg("kill -ABRT $$"_l);
+  process->AppendArg("-c"_l).AppendArg("kill -ABRT $$ && sleep 1"_l);
   ASSERT_FALSE(process->Run(1));
 }
 
 TEST_F(ProcessTest, ProcessCrashes) {
   ProcessPtr process = Process::Create(sh, String(), Process::SAME_UID);
-  process->AppendArg("-c"_l).AppendArg("kill -SEGV $$"_l);
+  process->AppendArg("-c"_l).AppendArg("kill -SEGV $$ && sleep 1"_l);
   ASSERT_FALSE(process->Run(1));
 }
 

--- a/src/base/process_test.cc
+++ b/src/base/process_test.cc
@@ -123,12 +123,14 @@ TEST_F(ProcessTest, DISABLED_WaitPidWithTimeOut) {
   // TODO: implement this test.
 }
 
+// FIXME: we shouldn't wait the signal for a second here
 TEST_F(ProcessTest, ProcessAborts) {
   ProcessPtr process = Process::Create(sh, String(), Process::SAME_UID);
   process->AppendArg("-c"_l).AppendArg("kill -ABRT $$ && sleep 1"_l);
   ASSERT_FALSE(process->Run(1));
 }
 
+// FIXME: we shouldn't wait the signal for a second here
 TEST_F(ProcessTest, ProcessCrashes) {
   ProcessPtr process = Process::Create(sh, String(), Process::SAME_UID);
   process->AppendArg("-c"_l).AppendArg("kill -SEGV $$ && sleep 1"_l);


### PR DESCRIPTION
The signal may have been delivered to tested sh process after
a syscall to exit(0), so the tests may have been flaky.