### PR TITLE
Support sanitizer blacklist file

### DIFF
--- a/src/base/base.proto
+++ b/src/base/base.proto
@@ -43,6 +43,9 @@ message Flags {
   repeated string non_direct   = 10;
   // flags, that shouldn't be neither direct cached, nor cached.
 
+  optional string sanitize_blacklist = 11;
+  // sanitizer blacklist file
+
   // Compilation = All
   // Preprocessing = All - output - cc_only
   // Cache = other + language + cc_only

--- a/src/base/const_string.cc
+++ b/src/base/const_string.cc
@@ -254,7 +254,7 @@ ConstString ConstString::operator+(const ConstString& other) const {
   return Rope{*this, other};
 }
 
-ConstString ConstString::Hash(ui8 output_size) {
+ConstString ConstString::Hash(ui8 output_size) const {
   // Implements the algorithm MurmurHash3 for x64 with 128 bits.
 
   if (empty()) {

--- a/src/base/const_string.h
+++ b/src/base/const_string.h
@@ -85,7 +85,7 @@ class ConstString {
     return !this->operator==(other);
   }
 
-  ConstString Hash(ui8 output_size = 16);  // 0-copy
+  ConstString Hash(ui8 output_size = 16) const;  // 0-copy
 
  private:
   struct Internal {

--- a/src/base/process.h
+++ b/src/base/process.h
@@ -20,14 +20,18 @@ FORWARD_TEST(ClientTest, SendPluginPath);
 }  // namespace client
 
 namespace daemon {
-FORWARD_TEST(AbsorberTest, StoreLocalCache);
+FORWARD_TEST(AbsorberTest, StoreLocalCacheWithoutBlacklist);
+FORWARD_TEST(AbsorberTest, StoreLocalCacheWithBlacklist);
+FORWARD_TEST(AbsorberTest, StoreLocalCacheWithAndWithoutBlacklist);
 FORWARD_TEST(CollectorTest, SimpleReport);
 FORWARD_TEST(CompilationDaemonTest, CreateProcessFromFlags);
 FORWARD_TEST(EmitterTest, LocalMessageWithPluginPath);
+FORWARD_TEST(EmitterTest, LocalMessageWithSanitizeBlacklist);
 FORWARD_TEST(EmitterTest, ConfigurationWithoutVersions);
 FORWARD_TEST(EmitterTest, LocalSuccessfulCompilation);
 FORWARD_TEST(EmitterTest, StoreSimpleCacheForLocalResult);
 FORWARD_TEST(EmitterTest, StoreSimpleCacheForRemoteResult);
+FORWARD_TEST(EmitterTest, StoreSimpleCacheForLocalResultWithAndWithoutBlacklist);
 FORWARD_TEST(EmitterTest, StoreDirectCacheForLocalResult);
 FORWARD_TEST(EmitterTest, StoreDirectCacheForRemoteResult);
 FORWARD_TEST(EmitterTest, UpdateConfiguration);
@@ -88,14 +92,18 @@ class Process
   FRIEND_TEST(client::ClientTest, SuccessfulCompilation);
   FRIEND_TEST(client::ClientTest, FailedCompilation);
   FRIEND_TEST(client::ClientTest, SendPluginPath);
-  FRIEND_TEST(daemon::AbsorberTest, StoreLocalCache);
+  FRIEND_TEST(daemon::AbsorberTest, StoreLocalCacheWithoutBlacklist);
+  FRIEND_TEST(daemon::AbsorberTest, StoreLocalCacheWithBlacklist);
+  FRIEND_TEST(daemon::AbsorberTest, StoreLocalCacheWithAndWithoutBlacklist);
   FRIEND_TEST(daemon::CollectorTest, SimpleReport);
   FRIEND_TEST(daemon::CompilationDaemonTest, CreateProcessFromFlags);
   FRIEND_TEST(daemon::EmitterTest, LocalMessageWithPluginPath);
+  FRIEND_TEST(daemon::EmitterTest, LocalMessageWithSanitizeBlacklist);
   FRIEND_TEST(daemon::EmitterTest, ConfigurationWithoutVersions);
   FRIEND_TEST(daemon::EmitterTest, LocalSuccessfulCompilation);
   FRIEND_TEST(daemon::EmitterTest, StoreSimpleCacheForLocalResult);
   FRIEND_TEST(daemon::EmitterTest, StoreSimpleCacheForRemoteResult);
+  FRIEND_TEST(daemon::EmitterTest, StoreSimpleCacheForLocalResultWithAndWithoutBlacklist);
   FRIEND_TEST(daemon::EmitterTest, StoreDirectCacheForLocalResult);
   FRIEND_TEST(daemon::EmitterTest, StoreDirectCacheForRemoteResult);
   FRIEND_TEST(daemon::EmitterTest, UpdateConfiguration);

--- a/src/cache/file_cache.h
+++ b/src/cache/file_cache.h
@@ -24,6 +24,12 @@ FORWARD_TEST(FileCacheMigratorTest, Version_0_to_1_Simple);
 FORWARD_TEST(FileCacheMigratorTest, Version_1_to_2_Direct);
 FORWARD_TEST(FileCacheMigratorTest, Version_1_to_2_Simple);
 
+enum ExtraFileType {
+  SANITIZE_BLACKLIST = 0,
+};
+
+using ExtraFiles = HashMap<ExtraFileType, Immutable>;
+
 namespace string {
 
 #define DEFINE_STRING_TYPE(type)                                          \
@@ -98,26 +104,31 @@ class FileCache {
   // |clean_period| is in seconds.
 
   static string::HandledHash Hash(string::HandledSource code,
+                                  const ExtraFiles& extra_files,
                                   string::CommandLine command_line,
                                   string::Version version);
 
   static string::UnhandledHash Hash(string::UnhandledSource code,
+                                    const ExtraFiles& extra_files,
                                     string::CommandLine command_line,
                                     string::Version version);
 
-  bool Find(string::HandledSource code, string::CommandLine command_line,
-            string::Version version, Entry* entry) const;
-
-  bool Find(string::UnhandledSource code, string::CommandLine command_line,
-            string::Version version, const String& current_dir,
+  bool Find(string::HandledSource code, const ExtraFiles& extra_files,
+            string::CommandLine command_line, string::Version version,
             Entry* entry) const;
 
-  void Store(string::UnhandledSource code, string::CommandLine command_line,
-             string::Version version, const List<String>& headers,
-             const String& current_dir, string::HandledHash hash);
+  bool Find(string::UnhandledSource code, const ExtraFiles& extra_files,
+            string::CommandLine command_line, string::Version version,
+            const String& current_dir, Entry* entry) const;
 
-  void Store(string::HandledSource code, string::CommandLine command_line,
-             string::Version version, const Entry& entry);
+  void Store(string::UnhandledSource code, const ExtraFiles& extra_files,
+             string::CommandLine command_line, string::Version version,
+             const List<String>& headers, const String& current_dir,
+             string::HandledHash hash);
+
+  void Store(string::HandledSource code, const ExtraFiles& extra_files,
+             string::CommandLine command_line, string::Version version,
+             const Entry& entry);
 
  private:
   FRIEND_TEST(FileCacheTest, DoubleLocks);

--- a/src/cache/file_cache_test.cc
+++ b/src/cache/file_cache_test.cc
@@ -15,10 +15,30 @@ using namespace string;
 
 TEST(FileCacheTest, HashCompliesWithRegex) {
   std::regex hash_regex("[a-f0-9]{32}-[a-f0-9]{8}-[a-f0-9]{8}");
-  EXPECT_TRUE(std::regex_match(
-      FileCache::Hash(HandledSource("1"_l), CommandLine("2"_l), Version("3"_l))
-          .str.string_copy(),
-      hash_regex));
+  EXPECT_TRUE(
+      std::regex_match(FileCache::Hash(HandledSource("1"_l), {},
+                                       CommandLine("3"_l), Version("4"_l))
+                           .str.string_copy(),
+                       hash_regex));
+  EXPECT_TRUE(
+      std::regex_match(FileCache::Hash(HandledSource("1"_l),
+                                       ExtraFiles{{SANITIZE_BLACKLIST, "21"_l}},
+                                       CommandLine("3"_l), Version("4"_l))
+                           .str.string_copy(),
+                       hash_regex));
+}
+
+TEST(FileCacheTest, ExtraFilesGiveDifferentHash) {
+  String hash_wo_extra_file =
+      FileCache::Hash(HandledSource("1"_l), {}, CommandLine("3"_l),
+                      Version("4"_l))
+          .str.string_copy();
+  String hash_with_extra_file =
+      FileCache::Hash(HandledSource("1"_l),
+                      ExtraFiles{{SANITIZE_BLACKLIST, "2"_l}},
+                      CommandLine("3"_l), Version("4"_l))
+          .str.string_copy();
+  EXPECT_NE(hash_wo_extra_file, hash_with_extra_file);
 }
 
 TEST(FileCacheTest, LockNonExistentFile) {
@@ -155,7 +175,7 @@ TEST(FileCacheTest, RestoreSingleEntry) {
 
   ASSERT_TRUE(base::File::Write(object_path, expected_object_code));
   ASSERT_TRUE(base::File::Write(deps_path, expected_deps));
-  EXPECT_FALSE(cache.Find(code, cl, version, &entry1));
+  EXPECT_FALSE(cache.Find(code, {}, cl, version, &entry1));
   EXPECT_TRUE(entry1.object.empty());
   EXPECT_TRUE(entry1.deps.empty());
   EXPECT_TRUE(entry1.stderr.empty());
@@ -164,9 +184,53 @@ TEST(FileCacheTest, RestoreSingleEntry) {
   entry1.deps = expected_deps;
   entry1.stderr = expected_stderr;
 
-  cache.Store(code, cl, version, entry1);
+  cache.Store(code, {}, cl, version, entry1);
 
-  ASSERT_TRUE(cache.Find(code, cl, version, &entry2));
+  ASSERT_TRUE(cache.Find(code, {}, cl, version, &entry2));
+  EXPECT_EQ(expected_object_code, entry2.object);
+  EXPECT_EQ(expected_deps, entry2.deps);
+  EXPECT_EQ(expected_stderr, entry2.stderr);
+}
+
+TEST(FileCacheTest, RestoreSingleEntryWithExtraFile) {
+  const base::TemporaryDir tmp_dir;
+  const String path = tmp_dir;
+  const String object_path = path + "/test.o";
+  const String deps_path = path + "/test.d";
+  const auto expected_stderr = "some warning"_l;
+  const auto expected_object_code = "some object code"_l;
+  const auto expected_deps = "some deps"_l;
+  FileCache cache(path);
+  ASSERT_TRUE(cache.Run(1));
+  FileCache::Entry entry1, entry2;
+
+  const HandledSource code("int main() { return 0; }"_l);
+  const Immutable extra_file("fun:main"_l);
+  const Immutable another_extra_file("fun:main "_l);
+  const CommandLine cl("-c"_l);
+  const Version version("3.5 (revision 100000)"_l);
+
+  ASSERT_TRUE(base::File::Write(object_path, expected_object_code));
+  ASSERT_TRUE(base::File::Write(deps_path, expected_deps));
+  EXPECT_FALSE(cache.Find(code, ExtraFiles{{SANITIZE_BLACKLIST, extra_file}},
+                          cl, version, &entry1));
+  EXPECT_TRUE(entry1.object.empty());
+  EXPECT_TRUE(entry1.deps.empty());
+  EXPECT_TRUE(entry1.stderr.empty());
+
+  entry1.object = expected_object_code;
+  entry1.deps = expected_deps;
+  entry1.stderr = expected_stderr;
+
+  cache.Store(code, ExtraFiles{{SANITIZE_BLACKLIST, extra_file}}, cl, version,
+              entry1);
+
+  EXPECT_FALSE(cache.Find(code, {}, cl, version, &entry2));
+  EXPECT_FALSE(cache.Find(code,
+                          ExtraFiles{{SANITIZE_BLACKLIST, another_extra_file}},
+                          cl, version, &entry2));
+  ASSERT_TRUE(cache.Find(code, ExtraFiles{{SANITIZE_BLACKLIST, extra_file}}, cl,
+                         version, &entry2));
   EXPECT_EQ(expected_object_code, entry2.object);
   EXPECT_EQ(expected_deps, entry2.deps);
   EXPECT_EQ(expected_stderr, entry2.stderr);
@@ -196,13 +260,13 @@ TEST(FileCacheTest, RestoreEntryWithMissingFile) {
   entry1.stderr = expected_stderr;
 
   // Store the entry.
-  cache.Store(code, cl, version, entry1);
+  cache.Store(code, {}, cl, version, entry1);
 
-  base::File::Delete(cache.CommonPath(FileCache::Hash(code, cl, version)) +
+  base::File::Delete(cache.CommonPath(FileCache::Hash(code, {}, cl, version)) +
                      ".d");
 
   // Restore the entry.
-  ASSERT_FALSE(cache.Find(code, cl, version, &entry2));
+  ASSERT_FALSE(cache.Find(code, {}, cl, version, &entry2));
 }
 
 TEST(FileCacheTest, DISABLED_RestoreEntryWithMalfordedManifest) {
@@ -261,7 +325,7 @@ TEST(FileCacheTest, ExceedCacheSize) {
 
   {
     FileCache::Entry entry{obj_content[0], String(), String()};
-    cache.Store(code[0], cl, version, entry);
+    cache.Store(code[0], {}, cl, version, entry);
     EXPECT_EQ(68u, base::CalculateDirectorySize(cache_path) - db_size);
   }
 
@@ -269,7 +333,7 @@ TEST(FileCacheTest, ExceedCacheSize) {
 
   {
     FileCache::Entry entry{obj_content[1], String(), String()};
-    cache.Store(code[1], cl, version, entry);
+    cache.Store(code[1], {}, cl, version, entry);
     EXPECT_EQ(137u, base::CalculateDirectorySize(cache_path) - db_size);
   }
 
@@ -277,15 +341,15 @@ TEST(FileCacheTest, ExceedCacheSize) {
 
   {
     FileCache::Entry entry{obj_content[2], String(), String()};
-    cache.Store(code[2], cl, version, entry);
+    cache.Store(code[2], {}, cl, version, entry);
     std::this_thread::sleep_for(std::chrono::seconds(3));
     EXPECT_EQ(70u, base::CalculateDirectorySize(cache_path) - db_size);
   }
 
   FileCache::Entry entry;
-  EXPECT_FALSE(cache.Find(code[0], cl, version, &entry));
-  EXPECT_FALSE(cache.Find(code[1], cl, version, &entry));
-  EXPECT_TRUE(cache.Find(code[2], cl, version, &entry));
+  EXPECT_FALSE(cache.Find(code[0], {}, cl, version, &entry));
+  EXPECT_FALSE(cache.Find(code[1], {}, cl, version, &entry));
+  EXPECT_TRUE(cache.Find(code[2], {}, cl, version, &entry));
 }
 
 TEST(FileCacheTest, RestoreDirectEntry) {
@@ -317,16 +381,72 @@ TEST(FileCacheTest, RestoreDirectEntry) {
   entry1.stderr = expected_stderr;
 
   // Store the entry.
-  cache.Store(code, cl, version, entry1);
+  cache.Store(code, {}, cl, version, entry1);
 
   // Store the direct entry.
   const UnhandledSource orig_code("int main() {}"_l);
   const List<String> headers = {header1_path, header2_rel_path};
-  cache.Store(orig_code, cl, version, headers, path,
-              FileCache::Hash(code, cl, version));
+  cache.Store(orig_code, {}, cl, version, headers, path,
+              FileCache::Hash(code, {}, cl, version));
 
   // Restore the entry.
-  ASSERT_TRUE(cache.Find(orig_code, cl, version, path, &entry2));
+  ASSERT_TRUE(cache.Find(orig_code, {}, cl, version, path, &entry2));
+  EXPECT_EQ(expected_object_code, entry2.object);
+  EXPECT_EQ(expected_deps, entry2.deps);
+  EXPECT_EQ(expected_stderr, entry2.stderr);
+}
+
+TEST(FileCacheTest, RestoreDirectEntryWithExtraFile) {
+  const base::TemporaryDir tmp_dir;
+  const String path = tmp_dir;
+  const String object_path = path + "/test.o";
+  const String deps_path = path + "/test.d";
+  const String header1_path = path + "/test1.h";
+  const String header2_path = path + "/test2.h";
+  const String header2_rel_path = "test2.h";
+  const auto expected_stderr = "some warning"_l;
+  const auto expected_object_code = "some object code"_l;
+  const auto expected_deps = "some deps"_l;
+  FileCache cache(path);
+  ASSERT_TRUE(cache.Run(1));
+  FileCache::Entry entry1, entry2;
+
+  const HandledSource code("int main() { return 0; }"_l);
+  const Immutable extra_file("fun:main"_l);
+  const Immutable another_extra_file("fun:main "_l);
+  const CommandLine cl("-c"_l);
+  const Version version("3.5 (revision 100000)"_l);
+
+  ASSERT_TRUE(base::File::Write(object_path, expected_object_code));
+  ASSERT_TRUE(base::File::Write(deps_path, expected_deps));
+  ASSERT_TRUE(base::File::Write(header1_path, "#define A"_l));
+  ASSERT_TRUE(base::File::Write(header2_path, "#define B"_l));
+
+  entry1.object = expected_object_code;
+  entry1.deps = expected_deps;
+  entry1.stderr = expected_stderr;
+
+  // Store the entry.
+  cache.Store(code, ExtraFiles{{SANITIZE_BLACKLIST, extra_file}}, cl, version,
+              entry1);
+
+  // Store the direct entry.
+  const UnhandledSource orig_code("int main() {}"_l);
+  const List<String> headers = {header1_path, header2_rel_path};
+  cache.Store(
+      orig_code, ExtraFiles{{SANITIZE_BLACKLIST, extra_file}}, cl, version,
+      headers, path,
+      FileCache::Hash(code, ExtraFiles{{SANITIZE_BLACKLIST, extra_file}}, cl,
+                      version));
+
+  // Restore the entry.
+  EXPECT_FALSE(cache.Find(orig_code, {}, cl, version, path, &entry2));
+  EXPECT_FALSE(cache.Find(orig_code,
+                          ExtraFiles{{SANITIZE_BLACKLIST, another_extra_file}},
+                          cl, version, path, &entry2));
+  ASSERT_TRUE(cache.Find(orig_code,
+                         ExtraFiles{{SANITIZE_BLACKLIST, extra_file}}, cl,
+                         version, path, &entry2));
   EXPECT_EQ(expected_object_code, entry2.object);
   EXPECT_EQ(expected_deps, entry2.deps);
   EXPECT_EQ(expected_stderr, entry2.stderr);
@@ -361,19 +481,19 @@ TEST(FileCacheTest, DirectEntry_ChangedHeaderContents) {
   entry.stderr = expected_stderr;
 
   // Store the entry.
-  cache.Store(code, cl, version, entry);
+  cache.Store(code, {}, cl, version, entry);
 
   // Store the direct entry.
   const UnhandledSource orig_code("int main() {}"_l);
   const List<String> headers = {header1_path, header2_rel_path};
-  cache.Store(orig_code, cl, version, headers, path,
-              FileCache::Hash(code, cl, version));
+  cache.Store(orig_code, {}, cl, version, headers, path,
+              FileCache::Hash(code, {}, cl, version));
 
   // Change header contents.
   ASSERT_TRUE(base::File::Write(header2_path, "#define C"_l));
 
   // Restore the entry.
-  EXPECT_FALSE(cache.Find(orig_code, cl, version, path, &entry));
+  EXPECT_FALSE(cache.Find(orig_code, {}, cl, version, path, &entry));
 }
 
 TEST(FileCacheTest, DirectEntry_RewriteManifest) {
@@ -405,22 +525,22 @@ TEST(FileCacheTest, DirectEntry_RewriteManifest) {
   entry1.stderr = expected_stderr;
 
   // Store the entry.
-  cache.Store(code, cl, version, entry1);
+  cache.Store(code, {}, cl, version, entry1);
 
   // Store the direct entry.
   const UnhandledSource orig_code("int main() {}"_l);
   List<String> headers = {header1_path, header2_path};
-  cache.Store(orig_code, cl, version, headers, path,
-              FileCache::Hash(code, cl, version));
+  cache.Store(orig_code, {}, cl, version, headers, path,
+              FileCache::Hash(code, {}, cl, version));
 
   headers.pop_back();
 
   // Store the direct entry - again.
-  cache.Store(orig_code, cl, version, headers, path,
-              FileCache::Hash(code, cl, version));
+  cache.Store(orig_code, {}, cl, version, headers, path,
+              FileCache::Hash(code, {}, cl, version));
 
   // Restore the entry.
-  EXPECT_TRUE(cache.Find(orig_code, cl, version, path, &entry2));
+  EXPECT_TRUE(cache.Find(orig_code, {}, cl, version, path, &entry2));
 }
 
 TEST(FileCacheTest, DirectEntry_ChangedOriginalCode) {
@@ -451,17 +571,65 @@ TEST(FileCacheTest, DirectEntry_ChangedOriginalCode) {
   entry.stderr = expected_stderr;
 
   // Store the entry.
-  cache.Store(code, cl, version, entry);
+  cache.Store(code, {}, cl, version, entry);
 
   // Store the direct entry.
   const UnhandledSource orig_code("int main() {}"_l);
   const List<String> headers = {header1_path, header2_path};
-  cache.Store(orig_code, cl, version, headers, path,
-              FileCache::Hash(code, cl, version));
+  cache.Store(orig_code, {}, cl, version, headers, path,
+              FileCache::Hash(code, {}, cl, version));
 
   // Restore the entry.
   const UnhandledSource bad_orig_code(orig_code.str.string_copy() + " ");
-  EXPECT_FALSE(cache.Find(bad_orig_code, cl, version, path, &entry));
+  EXPECT_FALSE(cache.Find(bad_orig_code, {}, cl, version, path, &entry));
+}
+
+TEST(FileCacheTest, DirectEntry_ChangedExtraFile) {
+  const base::TemporaryDir tmp_dir;
+  const String path = tmp_dir;
+  const String object_path = path + "/test.o";
+  const String deps_path = path + "/test.d";
+  const String header1_path = path + "/test1.h";
+  const String header2_path = path + "/test2.h";
+  const auto expected_stderr = "some warning"_l;
+  const auto expected_object_code = "some object code"_l;
+  const auto expected_deps = "some deps"_l;
+  FileCache cache(path);
+  ASSERT_TRUE(cache.Run(1));
+  FileCache::Entry entry;
+
+  const HandledSource code("int main() { return 0; }"_l);
+  const Immutable extra_file("fun:main"_l);
+  const CommandLine cl("-c"_l);
+  const Version version("3.5 (revision 100000)"_l);
+
+  ASSERT_TRUE(base::File::Write(object_path, expected_object_code));
+  ASSERT_TRUE(base::File::Write(deps_path, expected_deps));
+  ASSERT_TRUE(base::File::Write(header1_path, "#define A"_l));
+  ASSERT_TRUE(base::File::Write(header2_path, "#define B"_l));
+
+  entry.object = expected_object_code;
+  entry.deps = expected_deps;
+  entry.stderr = expected_stderr;
+
+  // Store the entry.
+  cache.Store(code, ExtraFiles{{SANITIZE_BLACKLIST, extra_file}}, cl, version,
+              entry);
+
+  // Store the direct entry.
+  const UnhandledSource orig_code("int main() {}"_l);
+  const List<String> headers = {header1_path, header2_path};
+  cache.Store(
+      orig_code, ExtraFiles{{SANITIZE_BLACKLIST, extra_file}}, cl, version,
+      headers, path,
+      FileCache::Hash(code, ExtraFiles{{SANITIZE_BLACKLIST, extra_file}}, cl,
+                      version));
+
+  // Restore the entry.
+  const Immutable new_extra_file("src:main.cc"_l);
+  EXPECT_FALSE(cache.Find(orig_code,
+                          ExtraFiles{{SANITIZE_BLACKLIST, new_extra_file}}, cl,
+                          version, path, &entry));
 }
 
 TEST(FileCacheTest, RestoreAndMigrateSnappyEntry) {
@@ -484,7 +652,7 @@ TEST(FileCacheTest, RestoreAndMigrateSnappyEntry) {
 
     ASSERT_TRUE(base::File::Write(object_path, expected_object_code));
     ASSERT_TRUE(base::File::Write(deps_path, expected_deps));
-    EXPECT_FALSE(cache.Find(code, cl, version, &entry1));
+    EXPECT_FALSE(cache.Find(code, {}, cl, version, &entry1));
     EXPECT_TRUE(entry1.object.empty());
     EXPECT_TRUE(entry1.deps.empty());
     EXPECT_TRUE(entry1.stderr.empty());
@@ -493,9 +661,9 @@ TEST(FileCacheTest, RestoreAndMigrateSnappyEntry) {
     entry1.deps = expected_deps;
     entry1.stderr = expected_stderr;
 
-    cache.Store(code, cl, version, entry1);
+    cache.Store(code, {}, cl, version, entry1);
 
-    ASSERT_TRUE(cache.Find(code, cl, version, &entry2));
+    ASSERT_TRUE(cache.Find(code, {}, cl, version, &entry2));
     EXPECT_EQ(expected_object_code, entry2.object);
     EXPECT_EQ(expected_deps, entry2.deps);
     EXPECT_EQ(expected_stderr, entry2.stderr);
@@ -507,7 +675,7 @@ TEST(FileCacheTest, RestoreAndMigrateSnappyEntry) {
     const HandledSource code("int main() { return 0; }"_l);
     const CommandLine cl("-c"_l);
     const Version version("3.5 (revision 100000)"_l);
-    ASSERT_TRUE(cache.Find(code, cl, version, &entry));
+    ASSERT_TRUE(cache.Find(code, {}, cl, version, &entry));
     EXPECT_EQ(expected_object_code, entry.object);
     EXPECT_EQ(expected_deps, entry.deps);
     EXPECT_EQ(expected_stderr, entry.stderr);

--- a/src/client/clang_command.cc
+++ b/src/client/clang_command.cc
@@ -86,6 +86,8 @@ bool ClangCommand::FillFlags(base::proto::Flags* flags,
       flags->set_output(arg->getValue());
     } else if (arg->getOption().matches(OPT_x)) {
       flags->set_language(arg->getValue());
+    } else if (arg->getOption().matches(OPT_fsanitize_blacklist)) {
+      flags->set_sanitize_blacklist(arg->getValue());
     }
 
     // Non-cacheable flags.

--- a/src/daemon/absorber.h
+++ b/src/daemon/absorber.h
@@ -23,6 +23,13 @@ class Absorber : public CompilationDaemon {
   bool HandleNewMessage(net::ConnectionPtr connection, Universal message,
                         const net::proto::Status& status) override;
 
+  cache::ExtraFiles GetExtraFiles(const proto::Remote* message);
+
+  bool PrepareExtraFilesForCompiler(const cache::ExtraFiles& extra_files,
+                                    const String& temp_dir_path,
+                                    base::proto::Flags* flags,
+                                    net::proto::Status* status);
+
   void DoExecute(const base::WorkerPool& pool);
 
   UniquePtr<Queue> tasks_;

--- a/src/daemon/absorber_test.cc
+++ b/src/daemon/absorber_test.cc
@@ -8,12 +8,12 @@ namespace daemon {
 
 namespace {
 
-// S1..4 types can be one of the following: |String|, |Immutable|, |Literal|
-template <typename S1, typename S2, typename S3, typename S4 = String>
-net::Connection::ScopedMessage CreateMessage(const S1& source,
-                                             const S2& action,
-                                             const S3& compiler_version,
-                                             const S4& language = S4()) {
+// S1..5 types can be one of the following: |String|, |Immutable|, |Literal|
+template <typename S1, typename S2, typename S3, typename S4 = String,
+          typename S5 = String>
+net::Connection::ScopedMessage CreateMessage(
+    const S1& source, const S2& action, const S3& compiler_version,
+    const S4& language = S4(), const S5& sanitize_blacklist = S5()) {
   net::Connection::ScopedMessage message(new net::Connection::Message);
   auto* extension = message->MutableExtension(proto::Remote::extension);
   extension->set_source(source);
@@ -22,6 +22,9 @@ net::Connection::ScopedMessage CreateMessage(const S1& source,
   extension->mutable_flags()->set_action(action);
   if (language != String()) {
     extension->mutable_flags()->set_language(language);
+  }
+  if (sanitize_blacklist != String()) {
+    extension->set_sanitize_blacklist(sanitize_blacklist);
   }
 
   return message;
@@ -113,6 +116,60 @@ TEST_F(AbsorberTest, SuccessfulCompilation) {
       << "Daemon must not store references to the connection";
 }
 
+TEST_F(AbsorberTest, SuccessfulCompilationWithBlacklist) {
+  const String expected_host = "fake_host";
+  const ui16 expected_port = 12345;
+  const net::proto::Status::Code expected_code = net::proto::Status::OK;
+  const String compiler_version = "fake_compiler_version";
+  const String compiler_path = "fake_compiler_path";
+
+  conf.mutable_absorber()->mutable_local()->set_host(expected_host);
+  conf.mutable_absorber()->mutable_local()->set_port(expected_port);
+  auto* version = conf.add_versions();
+  version->set_version(compiler_version);
+  version->set_path(compiler_path);
+
+  listen_callback = [&](const String& host, ui16 port, String*) {
+    EXPECT_EQ(expected_host, host);
+    EXPECT_EQ(expected_port, port);
+    return true;
+  };
+  connect_callback = [&](net::TestConnection* connection) {
+    connection->CallOnSend([&](const net::Connection::Message& message) {
+      EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
+      const auto& status = message.GetExtension(net::proto::Status::extension);
+      EXPECT_EQ(expected_code, status.code());
+
+      EXPECT_TRUE(message.HasExtension(proto::Result::extension));
+      EXPECT_TRUE(message.GetExtension(proto::Result::extension).has_obj());
+    });
+  };
+
+  absorber.reset(new Absorber(conf));
+  ASSERT_TRUE(absorber->Initialize());
+
+  auto connection = test_service->TriggerListen(expected_host, expected_port);
+  {
+    auto message(CreateMessage("fake_source"_l, "fake_action"_l,
+                               compiler_version, "", "sanitize_blacklist"));
+
+    SharedPtr<net::TestConnection> test_connection =
+        std::static_pointer_cast<net::TestConnection>(connection);
+    EXPECT_TRUE(
+        test_connection->TriggerReadAsync(std::move(message), StatusOK()));
+    absorber.reset();
+  }
+
+  EXPECT_EQ(1u, run_count);
+  EXPECT_EQ(1u, listen_count);
+  EXPECT_EQ(1u, connect_count);
+  EXPECT_EQ(1u, connections_created);
+  EXPECT_EQ(1u, read_count);
+  EXPECT_EQ(1u, send_count);
+  EXPECT_EQ(1, connection.use_count())
+      << "Daemon must not store references to the connection";
+}
+
 TEST_F(AbsorberTest, FailedCompilation) {
   const String expected_host = "fake_host";
   const ui16 expected_port = 12345;
@@ -166,7 +223,7 @@ TEST_F(AbsorberTest, FailedCompilation) {
       << "Daemon must not store references to the connection";
 }
 
-TEST_F(AbsorberTest, StoreLocalCache) {
+TEST_F(AbsorberTest, StoreLocalCacheWithoutBlacklist) {
   const base::TemporaryDir temp_dir;
   const String expected_host = "fake_host";
   const ui16 expected_port = 12345;
@@ -261,6 +318,205 @@ TEST_F(AbsorberTest, StoreLocalCache) {
   // TODO: check with deps file.
 }
 
+TEST_F(AbsorberTest, StoreLocalCacheWithBlacklist) {
+  const base::TemporaryDir temp_dir;
+  const String expected_host = "fake_host";
+  const ui16 expected_port = 12345;
+  const net::proto::Status::Code expected_code = net::proto::Status::OK;
+  const String compiler_version = "fake_compiler_version";
+  const String compiler_path = "fake_compiler_path";
+  const auto object_code = "fake_object_code"_l;
+  const String source = "fake_source";
+  const auto language = "c++"_l, converted_language = "c++-cpp-output"_l;
+  const auto action = "fake_action"_l;
+  const String sanitize_blacklist = "fake_sanitize_blacklist";
+
+  conf.mutable_absorber()->mutable_local()->set_host(expected_host);
+  conf.mutable_absorber()->mutable_local()->set_port(expected_port);
+  conf.mutable_cache()->set_path(temp_dir);
+  conf.mutable_cache()->set_direct(false);
+  conf.mutable_cache()->set_clean_period(1);
+
+  auto* version = conf.add_versions();
+  version->set_version(compiler_version);
+  version->set_path(compiler_path);
+
+  listen_callback = [&](const String& host, ui16 port, String*) {
+    EXPECT_EQ(expected_host, host);
+    EXPECT_EQ(expected_port, port);
+    return !::testing::Test::HasNonfatalFailure();
+  };
+
+  connect_callback = [&](net::TestConnection* connection) {
+    connection->CallOnSend([&](const net::Connection::Message& message) {
+      EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
+      const auto& status = message.GetExtension(net::proto::Status::extension);
+      EXPECT_EQ(expected_code, status.code()) << status.description();
+
+      EXPECT_TRUE(message.HasExtension(proto::Result::extension));
+      const auto& ext = message.GetExtension(proto::Result::extension);
+      EXPECT_TRUE(ext.has_obj());
+      EXPECT_EQ(String(object_code), ext.obj());
+
+      send_condition.notify_all();
+    });
+  };
+
+  run_callback = [&](base::TestProcess* process) {
+    auto process_args_iter = process->args_.begin();
+    EXPECT_EQ(action, *(process_args_iter++));
+    EXPECT_EQ("-x"_l, *(process_args_iter++));
+    EXPECT_EQ(converted_language, *(process_args_iter++));
+    EXPECT_EQ("-fsanitize-blacklist"_l, *(process_args_iter++));
+    ++process_args_iter;  // we don't know in advance which filename will
+                          // sanitize blacklist have on absorber
+    EXPECT_EQ("-o"_l, *(process_args_iter++));
+    EXPECT_EQ("-"_l, *(process_args_iter++));
+    EXPECT_EQ(process->args_.end(), process_args_iter);
+    process->stdout_ = object_code;
+  };
+
+  absorber.reset(new Absorber(conf));
+  ASSERT_TRUE(absorber->Initialize());
+
+  auto connection1 = test_service->TriggerListen(expected_host, expected_port);
+  {
+    auto message(CreateMessage(source, action, compiler_version, language,
+                               sanitize_blacklist));
+    SharedPtr<net::TestConnection> test_connection =
+        std::static_pointer_cast<net::TestConnection>(connection1);
+    EXPECT_TRUE(
+        test_connection->TriggerReadAsync(std::move(message), StatusOK()));
+
+    UniqueLock lock(send_mutex);
+    EXPECT_TRUE(send_condition.wait_for(lock, std::chrono::seconds(1),
+                                        [this] { return send_count == 1; }));
+  }
+
+  auto connection2 = test_service->TriggerListen(expected_host, expected_port);
+  {
+    auto message(CreateMessage(source, action, compiler_version, language,
+                               sanitize_blacklist));
+    SharedPtr<net::TestConnection> test_connection =
+        std::static_pointer_cast<net::TestConnection>(connection2);
+    EXPECT_TRUE(
+        test_connection->TriggerReadAsync(std::move(message), StatusOK()));
+
+    UniqueLock lock(send_mutex);
+    EXPECT_TRUE(send_condition.wait_for(lock, std::chrono::seconds(1),
+                                        [this] { return send_count == 2; }));
+  }
+
+  absorber.reset();
+
+  EXPECT_EQ(1u, run_count);
+  EXPECT_EQ(1u, listen_count);
+  EXPECT_EQ(2u, connect_count);
+  EXPECT_EQ(2u, connections_created);
+  EXPECT_EQ(2u, read_count);
+  EXPECT_EQ(2u, send_count);
+  EXPECT_EQ(1, connection1.use_count())
+      << "Daemon must not store references to the connection";
+  EXPECT_EQ(1, connection2.use_count())
+      << "Daemon must not store references to the connection";
+
+  // TODO: check with deps file.
+}
+
+TEST_F(AbsorberTest, StoreLocalCacheWithAndWithoutBlacklist) {
+  const base::TemporaryDir temp_dir;
+  const String expected_host = "fake_host";
+  const ui16 expected_port = 12345;
+  const net::proto::Status::Code expected_code = net::proto::Status::OK;
+  const String compiler_version = "fake_compiler_version";
+  const String compiler_path = "fake_compiler_path";
+  const auto object_code = "fake_object_code"_l;
+  const String source = "fake_source";
+  const auto language = "c++"_l;
+  const auto action = "fake_action"_l;
+  const String sanitize_blacklist = "fake_sanitize_blacklist";
+
+  conf.mutable_absorber()->mutable_local()->set_host(expected_host);
+  conf.mutable_absorber()->mutable_local()->set_port(expected_port);
+  conf.mutable_cache()->set_path(temp_dir);
+  conf.mutable_cache()->set_direct(false);
+  conf.mutable_cache()->set_clean_period(1);
+
+  auto* version = conf.add_versions();
+  version->set_version(compiler_version);
+  version->set_path(compiler_path);
+
+  listen_callback = [&](const String& host, ui16 port, String*) {
+    EXPECT_EQ(expected_host, host);
+    EXPECT_EQ(expected_port, port);
+    return !::testing::Test::HasNonfatalFailure();
+  };
+
+  connect_callback = [&](net::TestConnection* connection) {
+    connection->CallOnSend([&](const net::Connection::Message& message) {
+      EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
+      const auto& status = message.GetExtension(net::proto::Status::extension);
+      EXPECT_EQ(expected_code, status.code()) << status.description();
+
+      EXPECT_TRUE(message.HasExtension(proto::Result::extension));
+      const auto& ext = message.GetExtension(proto::Result::extension);
+      EXPECT_TRUE(ext.has_obj());
+      EXPECT_EQ(String(object_code), ext.obj());
+
+      send_condition.notify_all();
+    });
+  };
+
+  run_callback = [&](base::TestProcess* process) {
+    process->stdout_ = object_code;
+  };
+
+  absorber.reset(new Absorber(conf));
+  ASSERT_TRUE(absorber->Initialize());
+
+  auto connection1 = test_service->TriggerListen(expected_host, expected_port);
+  {
+    auto message(CreateMessage(source, action, compiler_version, language));
+    SharedPtr<net::TestConnection> test_connection =
+        std::static_pointer_cast<net::TestConnection>(connection1);
+    EXPECT_TRUE(
+        test_connection->TriggerReadAsync(std::move(message), StatusOK()));
+
+    UniqueLock lock(send_mutex);
+    EXPECT_TRUE(send_condition.wait_for(lock, std::chrono::seconds(1),
+                                        [this] { return send_count == 1; }));
+  }
+
+  auto connection2 = test_service->TriggerListen(expected_host, expected_port);
+  {
+    auto message(CreateMessage(source, action, compiler_version, language,
+                               sanitize_blacklist));
+    SharedPtr<net::TestConnection> test_connection =
+        std::static_pointer_cast<net::TestConnection>(connection2);
+    EXPECT_TRUE(
+        test_connection->TriggerReadAsync(std::move(message), StatusOK()));
+
+    UniqueLock lock(send_mutex);
+    EXPECT_TRUE(send_condition.wait_for(lock, std::chrono::seconds(1),
+                                        [this] { return send_count == 2; }));
+  }
+
+  absorber.reset();
+
+  EXPECT_EQ(2u, run_count);
+  EXPECT_EQ(1u, listen_count);
+  EXPECT_EQ(2u, connect_count);
+  EXPECT_EQ(2u, connections_created);
+  EXPECT_EQ(2u, read_count);
+  EXPECT_EQ(2u, send_count);
+  EXPECT_EQ(1, connection1.use_count())
+      << "Daemon must not store references to the connection";
+  EXPECT_EQ(1, connection2.use_count())
+      << "Daemon must not store references to the connection";
+
+  // TODO: check with deps file.
+}
+
 TEST_F(AbsorberTest, DISABLED_SkipTaskWithClosedConnection) {
   // TODO: implement this test.
   //       - Tasks should be skipped before any execution or sending attempt.
@@ -280,8 +536,8 @@ TEST_F(AbsorberTest, BadCompilerVersion) {
   version->set_version(compiler_version);
   version->set_path(compiler_path);
 
-  listen_callback =
-      [&expected_host, expected_port](const String& host, ui16 port, String*) {
+  listen_callback = [&expected_host, expected_port](const String& host,
+                                                    ui16 port, String*) {
     EXPECT_EQ(expected_host, host);
     EXPECT_EQ(expected_port, port);
     return true;
@@ -334,8 +590,8 @@ TEST_F(AbsorberTest, BadMessageStatus) {
   version->set_version(compiler_version);
   version->set_path(compiler_path);
 
-  listen_callback =
-      [&expected_host, expected_port](const String& host, ui16 port, String*) {
+  listen_callback = [&expected_host, expected_port](const String& host,
+                                                    ui16 port, String*) {
     EXPECT_EQ(expected_host, host);
     EXPECT_EQ(expected_port, port);
     return true;
@@ -359,8 +615,7 @@ TEST_F(AbsorberTest, BadMessageStatus) {
     SharedPtr<net::TestConnection> test_connection =
         std::static_pointer_cast<net::TestConnection>(connection);
     EXPECT_TRUE(test_connection->TriggerReadAsync(
-        CreateMessage(""_l, ""_l, ""_l),
-        StatusFor(expected_code)));
+        CreateMessage(""_l, ""_l, ""_l), StatusFor(expected_code)));
     absorber.reset();
   }
 

--- a/src/daemon/compilation_daemon.cc
+++ b/src/daemon/compilation_daemon.cc
@@ -10,6 +10,7 @@
 
 namespace dist_clang {
 
+using cache::ExtraFiles;
 using namespace cache::string;
 
 namespace {
@@ -25,8 +26,8 @@ inline String GetRelativePath(const String& current_dir, const String& input) {
     return input == current_dir ? String(".") : input;
   }
   return input.substr(0, current_dir.size()) == current_dir
-      ? input.substr(current_dir.size() + 1)
-      : input;
+             ? input.substr(current_dir.size() + 1)
+             : input;
 }
 
 inline CommandLine CommandLineForSimpleCache(const base::proto::Flags& flags) {
@@ -81,6 +82,10 @@ bool ParseDeps(String deps, List<String>& headers) {
   base::SplitString<' '>(lines.front().substr(deps_start), headers);
 
   return true;
+}
+
+inline String GetFullPath(const String& current_dir, const String& path) {
+  return path[0] == '/' ? path : current_dir + "/" + path;
 }
 
 }  // namespace
@@ -163,11 +168,12 @@ CompilationDaemon::CompilationDaemon(const proto::Configuration& configuration)
   }
 }
 
-HandledHash CompilationDaemon::GenerateHash(const base::proto::Flags& flags,
-                                            const HandledSource& code) const {
+HandledHash CompilationDaemon::GenerateHash(
+    const base::proto::Flags& flags, const HandledSource& code,
+    const ExtraFiles& extra_files) const {
   const Version version(flags.compiler().version());
-  return cache::FileCache::Hash(code, CommandLineForSimpleCache(flags),
-                                version);
+  return cache::FileCache::Hash(code, extra_files,
+                                CommandLineForSimpleCache(flags), version);
 }
 
 bool CompilationDaemon::SetupCompiler(base::proto::Flags* flags,
@@ -232,9 +238,32 @@ bool CompilationDaemon::SetupCompiler(base::proto::Flags* flags,
   return true;
 }
 
+bool CompilationDaemon::ReadExtraFiles(const base::proto::Flags& flags,
+                                       const String& current_dir,
+                                       ExtraFiles* extra_files) const {
+  DCHECK(extra_files);
+  DCHECK(extra_files->empty());
+
+  if (!flags.has_sanitize_blacklist()) {
+    return true;
+  }
+
+  Immutable sanitize_blacklist_contents;
+  const String sanitize_blacklist =
+      GetFullPath(current_dir, flags.sanitize_blacklist());
+  if (!base::File::Read(sanitize_blacklist, &sanitize_blacklist_contents)) {
+    LOG(CACHE_ERROR) << "Failed to read sanitize blacklist file"
+                     << sanitize_blacklist;
+    return false;
+  }
+  extra_files->emplace(cache::SANITIZE_BLACKLIST,
+                       std::move(sanitize_blacklist_contents));
+  return true;
+}
+
 bool CompilationDaemon::SearchSimpleCache(
     const base::proto::Flags& flags, const HandledSource& source,
-    cache::FileCache::Entry* entry) const {
+    const ExtraFiles& extra_files, cache::FileCache::Entry* entry) const {
   if (!cache_) {
     return false;
   }
@@ -242,7 +271,7 @@ bool CompilationDaemon::SearchSimpleCache(
   const Version version(flags.compiler().version());
   const auto command_line = CommandLineForSimpleCache(flags);
 
-  if (!cache_->Find(source, command_line, version, entry)) {
+  if (!cache_->Find(source, extra_files, command_line, version, entry)) {
     LOG(CACHE_INFO) << "Cache miss: " << flags.input();
     return false;
   }
@@ -262,9 +291,7 @@ bool CompilationDaemon::SearchDirectCache(
   }
 
   const Version version(flags.compiler().version());
-  const String input = flags.input()[0] != '/'
-                           ? current_dir + "/" + flags.input()
-                           : flags.input();
+  const String input = GetFullPath(current_dir, flags.input());
   const CommandLine command_line(CommandLineForDirectCache(current_dir, flags));
 
   UnhandledSource code;
@@ -272,7 +299,13 @@ bool CompilationDaemon::SearchDirectCache(
     return false;
   }
 
-  if (!cache_->Find(code, command_line, version, current_dir, entry)) {
+  ExtraFiles extra_files;
+  if (!ReadExtraFiles(flags, current_dir, &extra_files)) {
+    return false;
+  }
+
+  if (!cache_->Find(code, extra_files, command_line, version, current_dir,
+                    entry)) {
     LOG(CACHE_INFO) << "Direct cache miss: " << flags.input();
     return false;
   }
@@ -282,7 +315,7 @@ bool CompilationDaemon::SearchDirectCache(
 
 void CompilationDaemon::UpdateSimpleCache(
     const base::proto::Flags& flags, const HandledSource& source,
-    const cache::FileCache::Entry& entry) {
+    const ExtraFiles& extra_files, const cache::FileCache::Entry& entry) {
   const Version version(flags.compiler().version());
   const auto command_line = CommandLineForSimpleCache(flags);
 
@@ -290,12 +323,12 @@ void CompilationDaemon::UpdateSimpleCache(
     return;
   }
 
-  cache_->Store(source, command_line, version, entry);
+  cache_->Store(source, extra_files, command_line, version, entry);
 }
 
 void CompilationDaemon::UpdateDirectCache(
     const base::proto::Local* message, const HandledSource& source,
-    const cache::FileCache::Entry& entry) {
+    const ExtraFiles& extra_files, const cache::FileCache::Entry& entry) {
   const auto& flags = message->flags();
   auto config = conf();
   DCHECK(config->has_emitter() && !config->has_absorber());
@@ -312,19 +345,17 @@ void CompilationDaemon::UpdateDirectCache(
   }
 
   const Version version(flags.compiler().version());
-  const auto hash =
-      cache_->Hash(source, CommandLineForSimpleCache(flags), version);
-  const auto command_line = CommandLineForDirectCache(message->current_dir(),
-                                                      flags);
-  const String input_path = flags.input()[0] != '/'
-                                ? message->current_dir() + "/" + flags.input()
-                                : flags.input();
+  const auto hash = cache_->Hash(source, extra_files,
+                                 CommandLineForSimpleCache(flags), version);
+  const auto command_line =
+      CommandLineForDirectCache(message->current_dir(), flags);
+  const String input_path = GetFullPath(message->current_dir(), flags.input());
   List<String> headers;
   UnhandledSource original_code;
 
   if (ParseDeps(entry.deps, headers) &&
       base::File::Read(input_path, &original_code.str)) {
-    cache_->Store(original_code, command_line, version, headers,
+    cache_->Store(original_code, extra_files, command_line, version, headers,
                   message->current_dir(), hash);
   } else {
     LOG(CACHE_ERROR) << "Failed to parse deps or read input " << input_path;
@@ -357,6 +388,10 @@ base::ProcessPtr CompilationDaemon::CreateProcess(
   }
   if (flags.has_language()) {
     process->AppendArg("-x"_l).AppendArg(Immutable(flags.language()));
+  }
+  if (flags.has_sanitize_blacklist()) {
+    process->AppendArg("-fsanitize-blacklist"_l)
+        .AppendArg(Immutable(flags.sanitize_blacklist()));
   }
   if (flags.has_output()) {
     process->AppendArg("-o"_l).AppendArg(Immutable(flags.output()));

--- a/src/daemon/compilation_daemon.h
+++ b/src/daemon/compilation_daemon.h
@@ -22,14 +22,19 @@ class CompilationDaemon : public BaseDaemon {
   explicit CompilationDaemon(const proto::Configuration& configuration);
 
   cache::string::HandledHash GenerateHash(
-      const base::proto::Flags& flags,
-      const cache::string::HandledSource& code) const;
+      const base::proto::Flags& flags, const cache::string::HandledSource& code,
+      const cache::ExtraFiles& extra_files) const;
 
   bool SetupCompiler(base::proto::Flags* flags,
                      net::proto::Status* status) const;
 
+  bool ReadExtraFiles(const base::proto::Flags& flags,
+                      const String& current_dir,
+                      cache::ExtraFiles* extra_files) const;
+
   bool SearchSimpleCache(const base::proto::Flags& flags,
                          const cache::string::HandledSource& source,
+                         const cache::ExtraFiles& extra_files,
                          cache::FileCache::Entry* entry) const;
 
   bool SearchDirectCache(const base::proto::Flags& flags,
@@ -38,10 +43,12 @@ class CompilationDaemon : public BaseDaemon {
 
   void UpdateSimpleCache(const base::proto::Flags& flags,
                          const cache::string::HandledSource& source,
+                         const cache::ExtraFiles& extra_files,
                          const cache::FileCache::Entry& entry);
 
   void UpdateDirectCache(const base::proto::Local* message,
                          const cache::string::HandledSource& source,
+                         const cache::ExtraFiles& extra_files,
                          const cache::FileCache::Entry& entry);
 
   inline SharedPtr<const proto::Configuration> conf() const { return conf_; }

--- a/src/daemon/compilation_daemon_test.cc
+++ b/src/daemon/compilation_daemon_test.cc
@@ -9,9 +9,20 @@ namespace daemon {
 
 TEST(CompilationDaemonTest, CreateProcessFromFlags) {
   const List<Literal> expected_args = {
-      "-cc1"_l, "-emit-obj"_l, "-I."_l, "-load"_l, "/usr/lib/libplugin.so"_l,
-      "-dependency-file"_l, "some_deps_file"_l, "-x"_l, "c++"_l, "-o"_l,
-      "test.o"_l, "test.cc"_l,
+      "-cc1"_l,
+      "-emit-obj"_l,
+      "-I."_l,
+      "-load"_l,
+      "/usr/lib/libplugin.so"_l,
+      "-dependency-file"_l,
+      "some_deps_file"_l,
+      "-x"_l,
+      "c++"_l,
+      "-fsanitize-blacklist"_l,
+      "asan-blacklist.txt"_l,
+      "-o"_l,
+      "test.o"_l,
+      "test.cc"_l,
   };
   const ui32 expected_user_id = 1u;
 
@@ -26,6 +37,7 @@ TEST(CompilationDaemonTest, CreateProcessFromFlags) {
   flags.set_output("test.o");
   flags.set_language("c++");
   flags.set_deps_file("some_deps_file");
+  flags.set_sanitize_blacklist("asan-blacklist.txt");
 
   {
     base::ProcessPtr process =

--- a/src/daemon/emitter.h
+++ b/src/daemon/emitter.h
@@ -19,10 +19,12 @@ class Emitter : public CompilationDaemon {
     CONNECTION = 0,
     MESSAGE = 1,
     SOURCE = 2,
+    EXTRA_FILES = 3,
   };
 
   using Message = UniquePtr<base::proto::Local>;
-  using Task = Tuple<net::ConnectionPtr, Message, cache::string::HandledSource>;
+  using Task = Tuple<net::ConnectionPtr, Message, cache::string::HandledSource,
+                     cache::ExtraFiles>;
   using Queue = base::LockedQueue<Task>;
   using QueueAggregator = base::QueueAggregator<Task>;
   using Optional = Queue::Optional;
@@ -30,6 +32,9 @@ class Emitter : public CompilationDaemon {
 
   bool HandleNewMessage(net::ConnectionPtr connection, Universal message,
                         const net::proto::Status& status) override;
+
+  void SetExtraFiles(const cache::ExtraFiles& extra_files,
+                     proto::Remote* message);
 
   void DoCheckCache(const base::WorkerPool&);
   void DoLocalExecute(const base::WorkerPool&);

--- a/src/daemon/emitter_test.cc
+++ b/src/daemon/emitter_test.cc
@@ -1,7 +1,7 @@
 #include <daemon/emitter.h>
 
-#include <base/file_utils.h>
 #include <base/file/file.h>
+#include <base/file_utils.h>
 #include <base/temporary_dir.h>
 #include <daemon/common_daemon_test.h>
 #include <net/test_connection.h>
@@ -475,6 +475,77 @@ TEST_F(EmitterTest, LocalMessageWithPluginPath) {
     plugin->set_name(plugin_name);
     plugin->set_path(plugin_path);
     extension->mutable_flags()->set_action(action);
+
+    net::proto::Status status;
+    status.set_code(net::proto::Status::OK);
+
+    EXPECT_TRUE(test_connection->TriggerReadAsync(std::move(message), status));
+    emitter.reset();
+  }
+
+  EXPECT_EQ(1u, run_count);
+  EXPECT_EQ(1u, listen_count);
+  EXPECT_EQ(1u, connect_count);
+  EXPECT_EQ(1u, connections_created);
+  EXPECT_EQ(1u, read_count);
+  EXPECT_EQ(1u, send_count);
+  EXPECT_EQ(1, connection.use_count())
+      << "Daemon must not store references to the connection";
+
+  // TODO: check absolute output path.
+}
+
+TEST_F(EmitterTest, LocalMessageWithSanitizeBlacklist) {
+  const String socket_path = "/tmp/test.socket";
+  const auto expected_code = net::proto::Status::OK;
+  const String compiler_version = "fake_compiler_version";
+  const auto compiler_path = "fake_compiler_path"_l;
+  const String current_dir = "fake_current_dir";
+  const auto action = "fake_action"_l;
+  const auto sanitize_blacklist_path = "asan-blacklist.txt"_l;
+  const ui32 user_id = 1234;
+
+  conf.mutable_emitter()->set_socket_path(socket_path);
+  auto* version = conf.add_versions();
+  version->set_version(compiler_version);
+  version->set_path(compiler_path);
+
+  listen_callback = [&](const String& host, ui16 port, String*) {
+    EXPECT_EQ(socket_path, host);
+    EXPECT_EQ(0u, port);
+    return true;
+  };
+  connect_callback = [&](net::TestConnection* connection) {
+    connection->CallOnSend([&](const net::Connection::Message& message) {
+      EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
+      const auto& status = message.GetExtension(net::proto::Status::extension);
+      EXPECT_EQ(expected_code, status.code());
+    });
+  };
+  run_callback = [&](base::TestProcess* process) {
+    EXPECT_EQ(compiler_path, process->exec_path_);
+    EXPECT_EQ((Immutable::Rope{action, "-fsanitize-blacklist"_l,
+                               sanitize_blacklist_path}),
+              process->args_);
+    EXPECT_EQ(user_id, process->uid_);
+  };
+
+  emitter.reset(new Emitter(conf));
+  ASSERT_TRUE(emitter->Initialize());
+
+  auto connection = test_service->TriggerListen(socket_path);
+  {
+    SharedPtr<net::TestConnection> test_connection =
+        std::static_pointer_cast<net::TestConnection>(connection);
+
+    net::Connection::ScopedMessage message(new net::Connection::Message);
+    auto* extension = message->MutableExtension(base::proto::Local::extension);
+    extension->set_current_dir(current_dir);
+    extension->set_user_id(user_id);
+    auto* compiler = extension->mutable_flags()->mutable_compiler();
+    compiler->set_version(compiler_version);
+    extension->mutable_flags()->set_action(action);
+    extension->mutable_flags()->set_sanitize_blacklist(sanitize_blacklist_path);
 
     net::proto::Status status;
     status.set_code(net::proto::Status::OK);
@@ -1040,6 +1111,147 @@ TEST_F(EmitterTest, StoreSimpleCacheForRemoteResult) {
   // TODO: check that removal of original files doesn't fail cache filling.
 }
 
+TEST_F(EmitterTest, StoreSimpleCacheForLocalResultWithAndWithoutBlacklist) {
+  const base::TemporaryDir temp_dir;
+  const String socket_path = "/tmp/test.socket";
+  const auto expected_code = net::proto::Status::OK;
+  const String compiler_version = "fake_compiler_version";
+  const String compiler_path = "fake_compiler_path";
+  const auto source = "fake_source"_l;
+  const auto language = "fake_language"_l;
+  const auto action = "fake_action"_l;
+  const auto input_path = "test.cc"_l;
+  const auto output_path1 = "test1.o"_l;
+  const auto output_path2 = "test2.o"_l;
+  const auto plugin_name = "fake_plugin"_l;
+  const auto plugin_path = "fake_plugin_path"_l;
+  const auto sanitize_blacklist_path = "asan-blacklist.txt"_l;
+
+  conf.mutable_emitter()->set_socket_path(socket_path);
+  conf.mutable_cache()->set_path(temp_dir);
+  conf.mutable_cache()->set_direct(false);
+  conf.mutable_cache()->set_clean_period(1);
+
+  auto* version = conf.add_versions();
+  version->set_version(compiler_version);
+  version->set_path(compiler_path);
+  auto* plugin = version->add_plugins();
+  plugin->set_name(plugin_name);
+  plugin->set_path(plugin_path);
+
+  listen_callback = [&](const String& host, ui16 port, String*) {
+    EXPECT_EQ(socket_path, host);
+    EXPECT_EQ(0u, port);
+    return !::testing::Test::HasNonfatalFailure();
+  };
+
+  connect_callback = [&](net::TestConnection* connection) {
+    connection->CallOnSend([&](const net::Connection::Message& message) {
+      EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
+      const auto& status = message.GetExtension(net::proto::Status::extension);
+      EXPECT_EQ(expected_code, status.code()) << status.description();
+
+      send_condition.notify_all();
+    });
+  };
+
+  run_callback = [&](base::TestProcess* process) {
+    if (run_count == 1) {
+      EXPECT_EQ((Immutable::Rope{"-E"_l, "-x"_l, language, "-o"_l, "-"_l,
+                                 input_path}),
+                process->args_);
+      process->stdout_ = source;
+    } else if (run_count == 2) {
+      EXPECT_EQ((Immutable::Rope{action, "-load"_l, plugin_path, "-x"_l,
+                                 language, "-o"_l, output_path1, input_path}),
+                process->args_);
+    } else if (run_count == 3) {
+      EXPECT_EQ((Immutable::Rope{"-E"_l, "-x"_l, language, "-o"_l, "-"_l,
+                                 input_path}),
+                process->args_);
+      process->stdout_ = source;
+    } else if (run_count == 4) {
+      EXPECT_EQ((Immutable::Rope{action, "-load"_l, plugin_path, "-x"_l, language,
+              "-fsanitize-blacklist"_l, sanitize_blacklist_path, "-o"_l, output_path2, input_path}),
+        process->args_);
+    }
+  };
+
+  emitter.reset(new Emitter(conf));
+  ASSERT_TRUE(emitter->Initialize());
+
+  auto connection1 = test_service->TriggerListen(socket_path);
+  {
+    SharedPtr<net::TestConnection> test_connection =
+        std::static_pointer_cast<net::TestConnection>(connection1);
+
+    net::Connection::ScopedMessage message(new net::Connection::Message);
+    auto* extension = message->MutableExtension(base::proto::Local::extension);
+    extension->set_current_dir(temp_dir);
+
+    extension->mutable_flags()->set_input(input_path);
+    extension->mutable_flags()->set_output(output_path1);
+    auto* compiler = extension->mutable_flags()->mutable_compiler();
+    compiler->set_version(compiler_version);
+    compiler->add_plugins()->set_name(plugin_name);
+    extension->mutable_flags()->set_action(action);
+    extension->mutable_flags()->set_language(language);
+
+    net::proto::Status status;
+    status.set_code(net::proto::Status::OK);
+
+    EXPECT_TRUE(test_connection->TriggerReadAsync(std::move(message), status));
+
+    UniqueLock lock(send_mutex);
+    EXPECT_TRUE(send_condition.wait_for(lock, std::chrono::seconds(1),
+                                        [this] { return send_count == 1; }));
+  }
+
+  auto connection2 = test_service->TriggerListen(socket_path);
+  {
+    SharedPtr<net::TestConnection> test_connection =
+        std::static_pointer_cast<net::TestConnection>(connection2);
+
+    net::Connection::ScopedMessage message(new net::Connection::Message);
+    auto* extension = message->MutableExtension(base::proto::Local::extension);
+    extension->set_current_dir(temp_dir);
+
+    extension->mutable_flags()->set_input(input_path);
+    extension->mutable_flags()->set_output(output_path2);
+    auto* compiler = extension->mutable_flags()->mutable_compiler();
+    compiler->set_version(compiler_version);
+    compiler->add_plugins()->set_name(plugin_name);
+    extension->mutable_flags()->set_action(action);
+    extension->mutable_flags()->set_language(language);
+    extension->mutable_flags()->set_sanitize_blacklist(sanitize_blacklist_path);
+
+    net::proto::Status status;
+    status.set_code(net::proto::Status::OK);
+
+    EXPECT_TRUE(test_connection->TriggerReadAsync(std::move(message), status));
+
+    UniqueLock lock(send_mutex);
+    EXPECT_TRUE(send_condition.wait_for(lock, std::chrono::seconds(1),
+                                        [this] { return send_count == 2; }));
+  }
+
+  emitter.reset();
+
+  EXPECT_EQ(4u, run_count);
+  EXPECT_EQ(1u, listen_count);
+  EXPECT_EQ(2u, connect_count);
+  EXPECT_EQ(2u, connections_created);
+  EXPECT_EQ(2u, read_count);
+  EXPECT_EQ(2u, send_count);
+  EXPECT_EQ(1, connection1.use_count())
+      << "Daemon must not store references to the connection";
+  EXPECT_EQ(1, connection2.use_count())
+      << "Daemon must not store references to the connection";
+
+  // TODO: check that original files are not moved.
+  // TODO: check that removal of original files doesn't fail cache filling.
+}
+
 TEST_F(EmitterTest, StoreDirectCacheForLocalResult) {
   // Prepare environment.
   const base::TemporaryDir temp_dir;
@@ -1530,11 +1742,15 @@ TEST_F(EmitterTest, HitDirectCacheFromTwoLocations) {
   const auto path = Immutable(String(temp_dir1));
   const auto input_path = path + "/test.cc"_l;
   const auto header_path = path + "/header.h"_l;
+  const auto sanitize_blacklist_path = path + "/asan-blacklist.txt"_l;
   const auto source_code = "int main() {}"_l;
   const auto header_contents = "#define A"_l;
+  const auto sanitize_blacklist_contents = "fun:main"_l;
 
   ASSERT_TRUE(base::File::Write(input_path, source_code));
   ASSERT_TRUE(base::File::Write(header_path, header_contents));
+  ASSERT_TRUE(
+      base::File::Write(sanitize_blacklist_path, sanitize_blacklist_contents));
 
   // Prepare configuration.
   const String socket_path = "/tmp/test.socket";
@@ -1583,16 +1799,18 @@ TEST_F(EmitterTest, HitDirectCacheFromTwoLocations) {
 
   run_callback = [&](base::TestProcess* process) {
     if (run_count == 1) {
-      EXPECT_EQ((Immutable::Rope{"-E"_l, "-dependency-file"_l, deps_path,
-                                 "-x"_l, language, "-o"_l, "-"_l, input_path}),
-                process->args_);
+      EXPECT_EQ(
+          (Immutable::Rope{"-E"_l, "-dependency-file"_l, deps_path, "-x"_l,
+                           language, "-o"_l, "-"_l, input_path}),
+          process->args_);
       process->stdout_ = preprocessed_source;
       EXPECT_TRUE(base::File::Write(process->cwd_path_ + "/"_l + deps_path,
                                     deps_contents));
     } else if (run_count == 2) {
-      EXPECT_EQ((Immutable::Rope{action, "-load"_l, plugin_path,
-                                 "-dependency-file"_l, deps_path, "-x"_l,
-                                 language, "-o"_l, output_path, input_path}),
+      EXPECT_EQ((Immutable::Rope{
+                    action, "-load"_l, plugin_path, "-dependency-file"_l,
+                    deps_path, "-x"_l, language, "-fsanitize-blacklist"_l,
+                    sanitize_blacklist_path, "-o"_l, output_path, input_path}),
                 process->args_)
           << process->PrintArgs();
       EXPECT_TRUE(base::File::Write(process->cwd_path_ + "/"_l + output_path,
@@ -1620,6 +1838,7 @@ TEST_F(EmitterTest, HitDirectCacheFromTwoLocations) {
     compiler->add_plugins()->set_name(plugin_name);
     extension->mutable_flags()->set_action(action);
     extension->mutable_flags()->set_language(language);
+    extension->mutable_flags()->set_sanitize_blacklist(sanitize_blacklist_path);
 
     net::proto::Status status;
     status.set_code(net::proto::Status::OK);
@@ -1639,9 +1858,12 @@ TEST_F(EmitterTest, HitDirectCacheFromTwoLocations) {
     const auto path = Immutable(String(temp_dir2));
     const auto input_path = path + "/test.cc"_l;
     const auto header_path = path + "/header.h"_l;
+    const auto sanitize_blacklist_path = path + "/asan-blacklist.txt"_l;
 
     ASSERT_TRUE(base::File::Write(input_path, source_code));
     ASSERT_TRUE(base::File::Write(header_path, header_contents));
+    ASSERT_TRUE(base::File::Write(sanitize_blacklist_path,
+                                  sanitize_blacklist_contents));
 
     net::Connection::ScopedMessage message(new net::Connection::Message);
     auto* extension = message->MutableExtension(base::proto::Local::extension);
@@ -1655,6 +1877,7 @@ TEST_F(EmitterTest, HitDirectCacheFromTwoLocations) {
     compiler->add_plugins()->set_name(plugin_name);
     extension->mutable_flags()->set_action(action);
     extension->mutable_flags()->set_language(language);
+    extension->mutable_flags()->set_sanitize_blacklist(sanitize_blacklist_path);
 
     net::proto::Status status;
     status.set_code(net::proto::Status::OK);

--- a/src/daemon/remote.proto
+++ b/src/daemon/remote.proto
@@ -5,8 +5,10 @@ package dist_clang.daemon.proto;
 
 // Sent from emitter to absorber.
 message Remote {
-  optional base.proto.Flags flags = 1;
-  optional string source          = 2;
+  optional base.proto.Flags flags        = 1;
+  optional string source                 = 2;
+  optional string sanitize_blacklist     = 3;
+  // FIXME: replace with map after protobuf upgrade
 
   extend net.proto.Universal {
     optional Remote extension = 6;


### PR DESCRIPTION
* Support sanitize blacklist file

* Fix tests compilation

* Correct hash computation

* Get rid of ExtraFile type, use Immutable instead.

* Remove std::transform and std::accumulate calls.

* Refactor hash computation

* Review fixes

* Use HashMap instead of List for extra files.

* Move ExtraFiles type alias to FileCache, more tests.

* Add more tests

* Remove fsanitize-blacklist flag when preprocessing + one more test.