### PR TITLE
Move `conf_` to `BaseDaemon` since everyone uses it.

### DIFF
--- a/src/base/empty_lambda.h
+++ b/src/base/empty_lambda.h
@@ -11,7 +11,7 @@ class EmptyLambda {
 
   template <class... Args>
   ReturnType operator()(Args&&...) {
-    return ReturnType();
+    return value_;
   }
 
  private:

--- a/src/base/queue_aggregator.h
+++ b/src/base/queue_aggregator.h
@@ -34,6 +34,8 @@ class QueueAggregator {
     for (auto& thread : threads_) {
       thread.join();
     }
+
+    threads_.clear();
   }
 
   void Aggregate(LockedQueue<T>* WEAK_PTR queue) THREAD_UNSAFE {

--- a/src/daemon/absorber.cc
+++ b/src/daemon/absorber.cc
@@ -41,8 +41,8 @@ bool Absorber::Initialize() {
   auto config = conf();
   const auto& local = config->absorber().local();
   if (!Listen(local.host(), local.port(), local.ipv6(), &error)) {
-    LOG(ERROR) << "Failed to listen on " << local.host() << ":" << local.port()
-               << " : " << error;
+    LOG(ERROR) << "Absorber failed to listen on " << local.host() << ":"
+               << local.port() << " : " << error;
     return false;
   }
 

--- a/src/daemon/absorber_test.cc
+++ b/src/daemon/absorber_test.cc
@@ -80,7 +80,7 @@ TEST_F(AbsorberTest, SuccessfulCompilation) {
     EXPECT_EQ(expected_port, port);
     return true;
   };
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
@@ -89,6 +89,7 @@ TEST_F(AbsorberTest, SuccessfulCompilation) {
       EXPECT_TRUE(message.HasExtension(proto::Result::extension));
       EXPECT_TRUE(message.GetExtension(proto::Result::extension).has_obj());
     });
+    return true;
   };
 
   absorber.reset(new Absorber(conf));
@@ -134,7 +135,7 @@ TEST_F(AbsorberTest, SuccessfulCompilationWithBlacklist) {
     EXPECT_EQ(expected_port, port);
     return true;
   };
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
@@ -143,6 +144,7 @@ TEST_F(AbsorberTest, SuccessfulCompilationWithBlacklist) {
       EXPECT_TRUE(message.HasExtension(proto::Result::extension));
       EXPECT_TRUE(message.GetExtension(proto::Result::extension).has_obj());
     });
+    return true;
   };
 
   absorber.reset(new Absorber(conf));
@@ -188,7 +190,7 @@ TEST_F(AbsorberTest, FailedCompilation) {
     EXPECT_EQ(expected_port, port);
     return true;
   };
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
@@ -196,6 +198,7 @@ TEST_F(AbsorberTest, FailedCompilation) {
 
       EXPECT_FALSE(message.HasExtension(proto::Result::extension));
     });
+    return true;
   };
   do_run = false;
 
@@ -251,7 +254,7 @@ TEST_F(AbsorberTest, StoreLocalCacheWithoutBlacklist) {
     return !::testing::Test::HasNonfatalFailure();
   };
 
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
@@ -264,6 +267,7 @@ TEST_F(AbsorberTest, StoreLocalCacheWithoutBlacklist) {
 
       send_condition.notify_all();
     });
+    return true;
   };
 
   run_callback = [&](base::TestProcess* process) {
@@ -347,7 +351,7 @@ TEST_F(AbsorberTest, StoreLocalCacheWithBlacklist) {
     return !::testing::Test::HasNonfatalFailure();
   };
 
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
@@ -360,6 +364,7 @@ TEST_F(AbsorberTest, StoreLocalCacheWithBlacklist) {
 
       send_condition.notify_all();
     });
+    return true;
   };
 
   run_callback = [&](base::TestProcess* process) {
@@ -455,7 +460,7 @@ TEST_F(AbsorberTest, StoreLocalCacheWithAndWithoutBlacklist) {
     return !::testing::Test::HasNonfatalFailure();
   };
 
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
@@ -468,6 +473,7 @@ TEST_F(AbsorberTest, StoreLocalCacheWithAndWithoutBlacklist) {
 
       send_condition.notify_all();
     });
+    return true;
   };
 
   run_callback = [&](base::TestProcess* process) {
@@ -545,7 +551,8 @@ TEST_F(AbsorberTest, BadCompilerVersion) {
     EXPECT_EQ(expected_port, port);
     return true;
   };
-  connect_callback = [expected_code](net::TestConnection* connection) {
+  connect_callback = [expected_code](net::TestConnection* connection,
+                                     net::EndPointPtr) {
     connection->CallOnSend([expected_code](
         const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
@@ -554,6 +561,7 @@ TEST_F(AbsorberTest, BadCompilerVersion) {
 
       EXPECT_FALSE(message.HasExtension(proto::Result::extension));
     });
+    return true;
   };
 
   absorber.reset(new Absorber(conf));
@@ -599,7 +607,7 @@ TEST_F(AbsorberTest, BadMessageStatus) {
     EXPECT_EQ(expected_port, port);
     return true;
   };
-  connect_callback = [expected_code](net::TestConnection* connection) {
+  connect_callback = [expected_code](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([expected_code](
         const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
@@ -608,6 +616,7 @@ TEST_F(AbsorberTest, BadMessageStatus) {
 
       EXPECT_FALSE(message.HasExtension(proto::Result::extension));
     });
+    return true;
   };
 
   absorber.reset(new Absorber(conf));

--- a/src/daemon/base_daemon.cc
+++ b/src/daemon/base_daemon.cc
@@ -15,9 +15,11 @@ bool BaseDaemon::Initialize() {
 
 BaseDaemon::BaseDaemon(const proto::Configuration& configuration)
     : resolver_(net::EndPointResolver::Create()),
+      conf_(new proto::Configuration(configuration)),
       network_service_(net::NetworkService::Create(
           configuration.connect_timeout(), configuration.read_timeout(),
           configuration.send_timeout(), configuration.read_minimum())) {
+  conf_->CheckInitialized();
 }
 
 BaseDaemon::~BaseDaemon() {

--- a/src/daemon/collector.cc
+++ b/src/daemon/collector.cc
@@ -11,15 +11,16 @@ namespace dist_clang {
 namespace daemon {
 
 Collector::Collector(const proto::Configuration& configuration)
-    : BaseDaemon(configuration), local_(configuration.collector().local()) {
-  CHECK(configuration.has_collector());
+    : BaseDaemon(configuration) {
+  CHECK(conf()->has_collector());
 }
 
 bool Collector::Initialize() {
   String error;
-  if (!Listen(local_.host(), local_.port(), local_.ipv6(), &error)) {
-    LOG(ERROR) << "Failed to listen on " << local_.host() << ":"
-               << local_.port() << " : " << error;
+  const auto& local = conf()->collector().local();
+  if (!Listen(local.host(), local.port(), local.ipv6(), &error)) {
+    LOG(ERROR) << "Collector failed to listen on " << local.host() << ":"
+               << local.port() << " : " << error;
     return false;
   }
 

--- a/src/daemon/collector.h
+++ b/src/daemon/collector.h
@@ -10,16 +10,10 @@ class Collector : public BaseDaemon {
   explicit Collector(const proto::Configuration& configuration);
 
   bool Initialize() override;
-  inline bool UpdateConfiguration(
-      const proto::Configuration& configuration) override {
-    return true;
-  }
 
  private:
   bool HandleNewMessage(net::ConnectionPtr connection, Universal message,
                         const net::proto::Status& status) override;
-
-  const proto::Host local_;
 };
 
 }  // namespace daemon

--- a/src/daemon/collector_test.cc
+++ b/src/daemon/collector_test.cc
@@ -28,7 +28,7 @@ TEST_F(CollectorTest, SimpleReport) {
     EXPECT_EQ(expected_port, port);
     return true;
   };
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(perf::proto::Report::extension));
       const auto& report = message.GetExtension(perf::proto::Report::extension);
@@ -38,6 +38,7 @@ TEST_F(CollectorTest, SimpleReport) {
       EXPECT_EQ(perf::proto::Metric::SIMPLE_CACHE_HIT, report.metric(1).name());
       EXPECT_EQ(3u, report.metric(1).value());
     });
+    return true;
   };
 
   collector.reset(new Collector(conf));

--- a/src/daemon/compilation_daemon.cc
+++ b/src/daemon/compilation_daemon.cc
@@ -93,15 +93,15 @@ inline String GetFullPath(const String& current_dir, const String& path) {
 namespace daemon {
 
 bool CompilationDaemon::Initialize() {
-  if (conf_->has_cache() && !conf_->cache().disabled()) {
+  if (conf()->has_cache() && !conf()->cache().disabled()) {
     cache_.reset(new cache::FileCache(
-        conf_->cache().path(), conf_->cache().size(), conf_->cache().snappy(),
-        conf_->cache().store_index()));
-    if (!cache_->Run(conf_->cache().clean_period())) {
+        conf()->cache().path(), conf()->cache().size(),
+        conf()->cache().snappy(), conf()->cache().store_index()));
+    if (!cache_->Run(conf()->cache().clean_period())) {
       cache_.reset();
     }
   }
-  if (!UpdateConfiguration(*conf_)) {
+  if (!UpdateConfiguration(*conf())) {
     return false;
   }
 
@@ -110,7 +110,6 @@ bool CompilationDaemon::Initialize() {
 
 bool CompilationDaemon::UpdateConfiguration(
     const proto::Configuration& configuration) {
-  CHECK(conf_->IsInitialized());
   for (const auto& version : configuration.versions()) {
     if (!version.has_path() || version.path().empty()) {
       LOG(ERROR) << "Compiler " << version.version() << " has no path.";
@@ -124,20 +123,16 @@ bool CompilationDaemon::UpdateConfiguration(
       }
     }
   }
-  conf_.reset(new proto::Configuration(configuration));
   return BaseDaemon::UpdateConfiguration(configuration);
 }
 
 CompilationDaemon::CompilationDaemon(const proto::Configuration& configuration)
     : BaseDaemon(configuration) {
-  conf_.reset(new proto::Configuration(configuration));
-  conf_->CheckInitialized();
-
   // Setup log's verbosity early - even before configuration integrity check.
   // Everything else is done in the method |Initialize()|.
-  if (conf_->has_verbosity()) {
+  if (conf()->has_verbosity()) {
     base::Log::RangeSet ranges;
-    for (const auto& level : conf_->verbosity().levels()) {
+    for (const auto& level : conf()->verbosity().levels()) {
       if (level.has_left() && level.left() > level.right()) {
         continue;
       }
@@ -164,7 +159,7 @@ CompilationDaemon::CompilationDaemon(const proto::Configuration& configuration)
       }
       range_set.emplace(current.second, current.first);
     }
-    base::Log::Reset(conf_->verbosity().error_mark(), std::move(range_set));
+    base::Log::Reset(conf()->verbosity().error_mark(), std::move(range_set));
   }
 }
 

--- a/src/daemon/compilation_daemon.h
+++ b/src/daemon/compilation_daemon.h
@@ -51,12 +51,9 @@ class CompilationDaemon : public BaseDaemon {
                          const cache::ExtraFiles& extra_files,
                          const cache::FileCache::Entry& entry);
 
-  inline SharedPtr<const proto::Configuration> conf() const { return conf_; }
-
  private:
   using PluginNameMap = HashMap<String /* name */, String /* path */>;
 
-  SharedPtr<const proto::Configuration> conf_;
   UniquePtr<cache::FileCache> cache_;
 };
 

--- a/src/daemon/emitter.cc
+++ b/src/daemon/emitter.cc
@@ -137,8 +137,8 @@ bool Emitter::Initialize() {
   String error;
   auto config = conf();
   if (!Listen(config->emitter().socket_path(), &error)) {
-    LOG(ERROR) << "Failed to listen on " << config->emitter().socket_path()
-               << " : " << error;
+    LOG(ERROR) << "Emitter failed to listen on "
+               << config->emitter().socket_path() << " : " << error;
     return false;
   }
 

--- a/src/daemon/emitter_test.cc
+++ b/src/daemon/emitter_test.cc
@@ -85,13 +85,14 @@ TEST_F(EmitterTest, BadLocalMessage) {
     EXPECT_EQ(0u, port);
     return true;
   };
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
       EXPECT_EQ(expected_code, status.code());
       EXPECT_EQ(expected_description, status.description());
     });
+    return true;
   };
 
   emitter.reset(new Emitter(conf));
@@ -184,12 +185,13 @@ TEST_F(EmitterTest, LocalMessageWithBadCompiler) {
     EXPECT_EQ(0u, port);
     return true;
   };
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
       EXPECT_EQ(expected_code, status.code());
     });
+    return true;
   };
 
   emitter.reset(new Emitter(conf));
@@ -260,12 +262,13 @@ TEST_F(EmitterTest, RemoteMessageWithBadCompiler) {
     EXPECT_EQ(0u, port);
     return true;
   };
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
       EXPECT_EQ(expected_code, status.code());
     });
+    return true;
   };
 
   emitter.reset(new Emitter(conf));
@@ -317,12 +320,13 @@ TEST_F(EmitterTest, LocalMessageWithBadPlugin) {
     EXPECT_EQ(0u, port);
     return true;
   };
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
       EXPECT_EQ(expected_code, status.code());
     });
+    return true;
   };
 
   emitter.reset(new Emitter(conf));
@@ -381,12 +385,13 @@ TEST_F(EmitterTest, LocalMessageWithBadPlugin2) {
     EXPECT_EQ(0u, port);
     return true;
   };
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
       EXPECT_EQ(expected_code, status.code());
     });
+    return true;
   };
 
   emitter.reset(new Emitter(conf));
@@ -443,12 +448,13 @@ TEST_F(EmitterTest, LocalMessageWithPluginPath) {
     EXPECT_EQ(0u, port);
     return true;
   };
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
       EXPECT_EQ(expected_code, status.code());
     });
+    return true;
   };
   run_callback = [&](base::TestProcess* process) {
     EXPECT_EQ(compiler_path, process->exec_path_);
@@ -515,12 +521,13 @@ TEST_F(EmitterTest, LocalMessageWithSanitizeBlacklist) {
     EXPECT_EQ(0u, port);
     return true;
   };
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
       EXPECT_EQ(expected_code, status.code());
     });
+    return true;
   };
   run_callback = [&](base::TestProcess* process) {
     EXPECT_EQ(compiler_path, process->exec_path_);
@@ -584,12 +591,13 @@ TEST_F(EmitterTest, ConfigurationWithoutVersions) {
     EXPECT_EQ(0u, port);
     return true;
   };
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
       EXPECT_EQ(expected_code, status.code());
     });
+    return true;
   };
   run_callback = [&](base::TestProcess* process) {
     EXPECT_EQ(compiler_path, process->exec_path_);
@@ -661,12 +669,13 @@ TEST_F(EmitterTest, LocalSuccessfulCompilation) {
     EXPECT_EQ(0u, port);
     return true;
   };
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
       EXPECT_EQ(expected_code, status.code());
     });
+    return true;
   };
   run_callback = [&](base::TestProcess* process) {
     EXPECT_EQ(compiler_path, process->exec_path_);
@@ -735,12 +744,13 @@ TEST_F(EmitterTest, LocalFailedCompilation) {
     EXPECT_EQ(0u, port);
     return true;
   };
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
       EXPECT_EQ(expected_code, status.code());
     });
+    return true;
   };
   do_run = false;
 
@@ -818,7 +828,7 @@ TEST_F(EmitterTest, StoreSimpleCacheForLocalResult) {
     return !::testing::Test::HasNonfatalFailure();
   };
 
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
@@ -826,6 +836,7 @@ TEST_F(EmitterTest, StoreSimpleCacheForLocalResult) {
 
       send_condition.notify_all();
     });
+    return true;
   };
 
   run_callback = [&](base::TestProcess* process) {
@@ -972,7 +983,7 @@ TEST_F(EmitterTest, StoreSimpleCacheForRemoteResult) {
     return !::testing::Test::HasNonfatalFailure();
   };
 
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     if (connect_count == 1) {
       // Connection from client to local daemon.
 
@@ -1011,6 +1022,7 @@ TEST_F(EmitterTest, StoreSimpleCacheForRemoteResult) {
         send_condition.notify_all();
       });
     }
+    return true;
   };
 
   run_callback = [&](base::TestProcess* process) {
@@ -1145,7 +1157,7 @@ TEST_F(EmitterTest, StoreSimpleCacheForLocalResultWithAndWithoutBlacklist) {
     return !::testing::Test::HasNonfatalFailure();
   };
 
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
@@ -1153,6 +1165,7 @@ TEST_F(EmitterTest, StoreSimpleCacheForLocalResultWithAndWithoutBlacklist) {
 
       send_condition.notify_all();
     });
+    return true;
   };
 
   run_callback = [&](base::TestProcess* process) {
@@ -1309,7 +1322,7 @@ TEST_F(EmitterTest, StoreDirectCacheForLocalResult) {
     return !::testing::Test::HasNonfatalFailure();
   };
 
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
@@ -1317,6 +1330,7 @@ TEST_F(EmitterTest, StoreDirectCacheForLocalResult) {
 
       send_condition.notify_all();
     });
+    return true;
   };
 
   run_callback = [&](base::TestProcess* process) {
@@ -1486,7 +1500,7 @@ TEST_F(EmitterTest, StoreDirectCacheForRemoteResult) {
     return !::testing::Test::HasNonfatalFailure();
   };
 
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     if (connect_count == 1) {
       // Connection from client to local daemon.
 
@@ -1525,6 +1539,7 @@ TEST_F(EmitterTest, StoreDirectCacheForRemoteResult) {
         send_condition.notify_all();
       });
     }
+    return true;
   };
 
   run_callback = [&](base::TestProcess* process) {
@@ -1660,12 +1675,13 @@ TEST_F(EmitterTest, UpdateConfiguration) {
     EXPECT_EQ(0u, port);
     return true;
   };
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
       EXPECT_EQ(expected_code_no_version, status.code());
     });
+    return true;
   };
 
   emitter.reset(new Emitter(conf));
@@ -1696,12 +1712,13 @@ TEST_F(EmitterTest, UpdateConfiguration) {
   std::this_thread::sleep_for(std::chrono::seconds(1));
   emitter->UpdateConfiguration(conf);
 
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
       EXPECT_EQ(expected_code_ok, status.code());
     });
+    return true;
   };
   run_callback = [&](base::TestProcess* process) {
     EXPECT_EQ(compiler_path, process->exec_path_);
@@ -1790,7 +1807,7 @@ TEST_F(EmitterTest, HitDirectCacheFromTwoLocations) {
     return !::testing::Test::HasNonfatalFailure();
   };
 
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
@@ -1798,6 +1815,7 @@ TEST_F(EmitterTest, HitDirectCacheFromTwoLocations) {
 
       send_condition.notify_all();
     });
+    return true;
   };
 
   run_callback = [&](base::TestProcess* process) {
@@ -1994,7 +2012,7 @@ TEST_F(EmitterTest, DontHitDirectCacheFromTwoRelativeSources) {
     return !::testing::Test::HasNonfatalFailure();
   };
 
-  connect_callback = [&](net::TestConnection* connection) {
+  connect_callback = [&](net::TestConnection* connection, net::EndPointPtr) {
     connection->CallOnSend([&](const net::Connection::Message& message) {
       EXPECT_TRUE(message.HasExtension(net::proto::Status::extension));
       const auto& status = message.GetExtension(net::proto::Status::extension);
@@ -2002,6 +2020,7 @@ TEST_F(EmitterTest, DontHitDirectCacheFromTwoRelativeSources) {
 
       send_condition.notify_all();
     });
+    return true;
   };
 
   run_callback = [&](base::TestProcess* process) {

--- a/src/net/end_point.h
+++ b/src/net/end_point.h
@@ -16,6 +16,8 @@ class EndPoint : public std::enable_shared_from_this<EndPoint> {
   static EndPointPtr LocalHost(const String& host, ui16 port, bool ipv6);
   static EndPointPtr UnixSocket(const String& path);
 
+  virtual ~EndPoint() {}
+
   operator const sockaddr*() const {
     return reinterpret_cast<const sockaddr*>(&address_);
   }
@@ -26,7 +28,7 @@ class EndPoint : public std::enable_shared_from_this<EndPoint> {
   int type() const { return SOCK_STREAM; }
   int protocol() const { return protocol_; }
 
-  String Print() const;
+  virtual String Print() const;
 
  private:
   sockaddr_storage address_;

--- a/src/net/test_end_point.h
+++ b/src/net/test_end_point.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <net/end_point.h>
+
+namespace dist_clang {
+namespace net {
+
+// TODO(ilezhankin): rewrite this stuff using |Testable| and factories, if possible.
+class TestEndPoint : public EndPoint {
+ public:
+  TestEndPoint(const String& host, ui16 port = 0u) : host_(host), port_(port) {}
+  String Print() const override { return host_ + ":" + std::to_string(port_); }
+
+ private:
+  const String host_;
+  const ui16 port_;
+};
+
+}  // namespace net
+}  // namespace dist_clang

--- a/src/net/test_end_point_resolver.h
+++ b/src/net/test_end_point_resolver.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <net/end_point.h>
 #include <net/end_point_resolver.h>
+#include <net/test_end_point.h>
 
 namespace dist_clang {
 namespace net {
@@ -15,8 +15,8 @@ class TestEndPointResolver : public EndPointResolver {
     }
   };
 
-  Optional Resolve(const String&, ui16, bool) override {
-    return Promise(EndPointPtr(new EndPoint)).GetFuture();
+  Optional Resolve(const String& host, ui16 port, bool) override {
+    return Promise(EndPointPtr(new TestEndPoint(host, port))).GetFuture();
   }
 };
 

--- a/src/net/test_network_service.cc
+++ b/src/net/test_network_service.cc
@@ -1,6 +1,7 @@
 #include <net/test_network_service.h>
 
 #include <net/test_connection.h>
+#include <net/test_end_point.h>
 
 namespace dist_clang {
 namespace net {
@@ -50,7 +51,7 @@ ConnectionPtr TestNetworkService::TriggerListen(const String& host, ui16 port) {
     if (connect_attempts_) {
       (*connect_attempts_)++;
     }
-    auto new_connection = on_connect_(EndPointPtr(), nullptr);
+    auto new_connection = on_connect_(EndPointPtr(new TestEndPoint(host, port)), nullptr);
     it->second(new_connection);
     return new_connection;
   }


### PR DESCRIPTION
Make `conf_` thread-safe.
Implement testable `EndPoint` - for future tests with `Connect()`.

Original author is @matthewttf