### PR TITLE
Added distribution support to LockedQueue

### DIFF
--- a/build/travis.sh
+++ b/build/travis.sh
@@ -14,7 +14,7 @@ elif [[ "$(uname)" == Darwin ]]; then
     arch="Mac"
 fi
 
-clang_revision=283753-1
+clang_revision=282487-1
 clang_root="$root_dir/out/clang-$clang_revision"
 if ! test -d "$clang_root"; then
     mkdir "$clang_root"

--- a/src/base/locked_queue.h
+++ b/src/base/locked_queue.h
@@ -5,7 +5,7 @@
 
 #include STL(condition_variable)
 #include STL(experimental/optional)
-#include STL(queue)
+#include STL(list)
 
 namespace dist_clang {
 namespace base {
@@ -17,6 +17,18 @@ template <class T>
 class LockedQueue {
  public:
   using Optional = std::experimental::optional<T>;
+  using Queue = List<T>;
+  enum InfoIndex {
+    ITERATOR = 0u,
+    HASH = 1u,
+  };
+  enum ReverseInfoIndex {
+    RANGE = 0u,
+    REVERSE_ITERATOR = 1u,
+  };
+  using TaskInfo = Tuple<typename Queue::iterator, size_t>;
+  // List of tasks from same 'range' in terms of distributed tasks.
+  using RangeList = List<TaskInfo>;
 
   enum {
     UNLIMITED = 0,
@@ -24,7 +36,18 @@ class LockedQueue {
 
   LockedQueue() = default;
   explicit LockedQueue(ui32 capacity) : capacity_(capacity) {}
-  ~LockedQueue() { DCHECK(closed_); }
+  ~LockedQueue() {
+    DCHECK(closed_);
+#if !defined(NDEBUG)
+    // Make sure we don't leak tasks.
+    DCHECK(reverse_index_.size() == queue_.size());
+    size_t index_size = 0u;
+    for (const RangeList& range_list : index_) {
+      index_size += range_list.size();
+    }
+    DCHECK(index_size == queue_.size());
+#endif  // !defined(NDEBUG)
+  }
 
   // Should be explicitly closed before destruction.
   void Close() THREAD_SAFE {
@@ -37,7 +60,7 @@ class LockedQueue {
 
   // Returns |false| only when this queue is closed or when the capacity is
   // exceeded.
-  bool Push(T obj) THREAD_SAFE {
+  bool Push(T obj, const ui64 hash = 0u) THREAD_SAFE {
     if (closed_) {
       return false;
     }
@@ -47,7 +70,11 @@ class LockedQueue {
       if (queue_.size() >= capacity_ && capacity_ != UNLIMITED) {
         return false;
       }
-      queue_.push(std::move(obj));
+      queue_.push_back(std::move(obj));
+      auto last = queue_.end();
+      --last;
+
+      PutToIndex(last, hash);
     }
     ++size_;
     pop_condition_.notify_one();
@@ -56,41 +83,92 @@ class LockedQueue {
   }
 
   // Returns disengaged object only when this queue is closed and empty.
-  Optional Pop() THREAD_SAFE {
+  Optional Pop(const ui32 range_index = 0u) THREAD_SAFE {
+    return Pop(nullptr, range_index);
+  }
+
+  Optional Pop(Atomic<ui64>* external_counter,
+               const ui32 range_index = 0u) THREAD_SAFE {
     UniqueLock lock(pop_mutex_);
     pop_condition_.wait(lock, [this] { return closed_ || !queue_.empty(); });
     if (closed_ && queue_.empty()) {
       return Optional();
     }
-    Optional&& obj = std::move(queue_.front());
-    queue_.pop();
+
+    auto task = GetFromIndex(range_index);
+
+    Optional&& obj = std::move(*task);
+    queue_.erase(task);
     --size_;
+    if (external_counter) {
+      ++(*external_counter);
+    }
     return std::move(obj);
   }
 
-  Optional Pop(Atomic<ui64>& external_counter) THREAD_SAFE {
+  void UpdateDistribution(const ui32 distribution_range) THREAD_SAFE {
+    CHECK(distribution_range > 0u);
     UniqueLock lock(pop_mutex_);
-    pop_condition_.wait(lock, [this] { return closed_ || !queue_.empty(); });
     if (closed_ && queue_.empty()) {
-      return Optional();
+      index_.resize(distribution_range);
+      return;
     }
-    Optional&& obj = std::move(queue_.front());
-    queue_.pop();
-    --size_;
-    ++external_counter;
-    return std::move(obj);
+    Vector<RangeList> old_index(index_);
+    reverse_index_.clear();
+    index_.clear();
+    index_.resize(distribution_range);
+    chunk_size_ = std::numeric_limits<size_t>::max() / distribution_range;
+    for (const RangeList& range_list : old_index) {
+      for (const TaskInfo& task_info : range_list) {
+        PutToIndex(std::get<ITERATOR>(task_info), std::get<HASH>(task_info));
+      }
+    }
   }
 
  private:
   friend class QueueAggregator<T>;
 
+  void PutToIndex(typename Queue::iterator item, const ui64 hash) {
+    const ui32 range = static_cast<ui32>(hash / chunk_size_);
+    CHECK(range < index_.size()) << "Invalid range for hash / chunk_size "
+                                 << hash << "/" << chunk_size_;
+    index_[range].emplace_back(std::make_tuple(item, hash));
+    typename RangeList::iterator last = index_[range].end();
+    --last;
+
+    const T* const item_pointer = &(*item);
+    reverse_index_[item_pointer] = std::make_tuple(range, last);
+  }
+
+  typename Queue::iterator GetFromIndex(const ui32 range_index) {
+    typename Queue::iterator task;
+    if (range_index < index_.size() && index_[range_index].size() > 0) {
+      task = std::get<ITERATOR>(index_[range_index].front());
+    } else {
+      task = queue_.begin();
+    }
+    // Clean up all indexes:
+    const T* const task_pointer = &(*task);
+    const auto& reverse_info =  reverse_index_[task_pointer];
+    RangeList& range_list = index_[std::get<RANGE>(reverse_info)];
+    range_list.erase(std::get<REVERSE_ITERATOR>(reverse_info));
+    reverse_index_.erase(task_pointer);
+    return task;
+  }
+
   std::mutex pop_mutex_;
   std::condition_variable pop_condition_;
-  std::queue<T> queue_;
+  Queue queue_;
 
   Atomic<ui64> size_ = {0};
   const ui64 capacity_ = UNLIMITED;
   Atomic<bool> closed_ = {false};
+  size_t chunk_size_ = {std::numeric_limits<size_t>::max()};
+  Vector<RangeList> index_{1};
+  // |reverse_index_| is used to remove tasks from |index_| in O(1) when
+  // those are picked from the top of the |queue_|.
+  HashMap<const T*,
+          std::tuple<size_t, typename RangeList::iterator>> reverse_index_;
 };
 
 }  // namespace base

--- a/src/base/locked_queue.h
+++ b/src/base/locked_queue.h
@@ -124,6 +124,7 @@ class LockedQueue {
       }
       return index_size;
     }
+
     void Put(typename Queue::iterator item, const ui64 hash) {
       const ui32 shard = static_cast<ui32>(hash / chunk_size_);
       CHECK(shard < index_.size()) << "Invalid shard for hash / chunk_size "

--- a/src/base/locked_queue.h
+++ b/src/base/locked_queue.h
@@ -5,7 +5,6 @@
 
 #include STL(condition_variable)
 #include STL(experimental/optional)
-#include STL(list)
 
 namespace dist_clang {
 namespace base {
@@ -18,35 +17,16 @@ class LockedQueue {
  public:
   using Optional = std::experimental::optional<T>;
   using Queue = List<T>;
-  enum InfoIndex {
-    ITERATOR = 0u,
-    HASH = 1u,
-  };
-  enum ReverseInfoIndex {
-    RANGE = 0u,
-    REVERSE_ITERATOR = 1u,
-  };
-  using TaskInfo = Tuple<typename Queue::iterator, size_t>;
-  // List of tasks from same 'range' in terms of distributed tasks.
-  using RangeList = List<TaskInfo>;
 
   enum {
     UNLIMITED = 0,
   };
 
-  LockedQueue() = default;
-  explicit LockedQueue(ui32 capacity) : capacity_(capacity) {}
+  LockedQueue() : index_(this) {}
+  explicit LockedQueue(ui32 capacity) : capacity_(capacity), index_(this) {}
   ~LockedQueue() {
     DCHECK(closed_);
-#if !defined(NDEBUG)
-    // Make sure we don't leak tasks.
-    DCHECK(reverse_index_.size() == queue_.size());
-    size_t index_size = 0u;
-    for (const RangeList& range_list : index_) {
-      index_size += range_list.size();
-    }
-    DCHECK(index_size == queue_.size());
-#endif  // !defined(NDEBUG)
+    DCHECK(index_.Size() == queue_.size());
   }
 
   // Should be explicitly closed before destruction.
@@ -74,7 +54,7 @@ class LockedQueue {
       auto last = queue_.end();
       --last;
 
-      PutToIndex(last, hash);
+      index_.Put(last, hash);
     }
     ++size_;
     pop_condition_.notify_one();
@@ -83,19 +63,19 @@ class LockedQueue {
   }
 
   // Returns disengaged object only when this queue is closed and empty.
-  Optional Pop(const ui32 range_index = 0u) THREAD_SAFE {
-    return Pop(nullptr, range_index);
+  Optional Pop(const ui32 shard = 0u) THREAD_SAFE {
+    return Pop(nullptr, shard);
   }
 
   Optional Pop(Atomic<ui64>* external_counter,
-               const ui32 range_index = 0u) THREAD_SAFE {
+               const ui32 shard = 0u) THREAD_SAFE {
     UniqueLock lock(pop_mutex_);
     pop_condition_.wait(lock, [this] { return closed_ || !queue_.empty(); });
     if (closed_ && queue_.empty()) {
       return Optional();
     }
 
-    auto task = GetFromIndex(range_index);
+    auto task = index_.Get(shard);
 
     Optional&& obj = std::move(*task);
     queue_.erase(task);
@@ -106,55 +86,98 @@ class LockedQueue {
     return std::move(obj);
   }
 
-  void UpdateDistribution(const ui32 distribution_range) THREAD_SAFE {
-    CHECK(distribution_range > 0u);
+  void UpdateIndex(const ui32 shards_number) THREAD_SAFE {
+    CHECK(shards_number > 0u);
     UniqueLock lock(pop_mutex_);
-    if (closed_ && queue_.empty()) {
-      index_.resize(distribution_range);
-      return;
-    }
-    Vector<RangeList> old_index(index_);
-    reverse_index_.clear();
-    index_.clear();
-    index_.resize(distribution_range);
-    chunk_size_ = std::numeric_limits<size_t>::max() / distribution_range;
-    for (const RangeList& range_list : old_index) {
-      for (const TaskInfo& task_info : range_list) {
-        PutToIndex(std::get<ITERATOR>(task_info), std::get<HASH>(task_info));
-      }
-    }
+    index_.Update(shards_number);
   }
 
  private:
   friend class QueueAggregator<T>;
 
-  void PutToIndex(typename Queue::iterator item, const ui64 hash) {
-    const ui32 range = static_cast<ui32>(hash / chunk_size_);
-    CHECK(range < index_.size()) << "Invalid range for hash / chunk_size "
-                                 << hash << "/" << chunk_size_;
-    index_[range].emplace_back(std::make_tuple(item, hash));
-    typename RangeList::iterator last = index_[range].end();
-    --last;
+  class Index {
+   public:
+    using TaskInfo = Tuple<typename Queue::iterator, size_t>;
+    using ShardsList = List<TaskInfo>;  // List of tasks from same shard.
+    enum InfoIndex {
+      ITERATOR = 0u,
+      HASH = 1u,
+    };
+    enum ReverseInfoIndex {
+      RANGE = 0u,
+      REVERSE_ITERATOR = 1u,
+    };
 
-    const T* const item_pointer = &(*item);
-    reverse_index_[item_pointer] = std::make_tuple(range, last);
-  }
-
-  typename Queue::iterator GetFromIndex(const ui32 range_index) {
-    typename Queue::iterator task;
-    if (range_index < index_.size() && index_[range_index].size() > 0) {
-      task = std::get<ITERATOR>(index_[range_index].front());
-    } else {
-      task = queue_.begin();
+    Index(LockedQueue<T>* const queue) : queue_(queue) {
+      CHECK(queue_) << "Queue must be specified";
     }
-    // Clean up all indexes:
-    const T* const task_pointer = &(*task);
-    const auto& reverse_info =  reverse_index_[task_pointer];
-    RangeList& range_list = index_[std::get<RANGE>(reverse_info)];
-    range_list.erase(std::get<REVERSE_ITERATOR>(reverse_info));
-    reverse_index_.erase(task_pointer);
-    return task;
-  }
+
+    ~Index() {
+      // Make sure we don't leak tasks.
+      DCHECK(reverse_index_.size() == Size());
+    }
+
+    size_t Size() const THREAD_UNSAFE {
+      size_t index_size = 0u;
+      for (const ShardsList& shards_list : index_) {
+        index_size += shards_list.size();
+      }
+      return index_size;
+    }
+    void Put(typename Queue::iterator item, const ui64 hash) {
+      const ui32 shard = static_cast<ui32>(hash / chunk_size_);
+      CHECK(shard < index_.size()) << "Invalid shard for hash / chunk_size "
+                                   << hash << "/" << chunk_size_;
+      index_[shard].emplace_back(std::make_tuple(item, hash));
+      typename ShardsList::iterator last = index_[shard].end();
+      --last;
+
+      const T* const item_pointer = &(*item);
+      reverse_index_[item_pointer] = std::make_tuple(shard, last);
+    }
+
+    typename Queue::iterator Get(const ui32 shard) {
+      typename Queue::iterator task;
+      if (shard < index_.size() && index_[shard].size() > 0) {
+        task = std::get<ITERATOR>(index_[shard].front());
+      } else {
+        task = queue_->queue_.begin();
+      }
+      // Clean up all indexes:
+      const T* const task_pointer = &(*task);
+      const auto& reverse_info =  reverse_index_[task_pointer];
+      ShardsList& shards_list = index_[std::get<RANGE>(reverse_info)];
+      shards_list.erase(std::get<REVERSE_ITERATOR>(reverse_info));
+      reverse_index_.erase(task_pointer);
+      return task;
+    }
+
+    void Update(const ui32 shards_number) THREAD_UNSAFE {
+      if (queue_->closed_ && queue_->queue_.empty()) {
+        index_.resize(shards_number);
+        return;
+      }
+      Vector<ShardsList> old_index(index_);
+      reverse_index_.clear();
+      index_.clear();
+      index_.resize(shards_number);
+      chunk_size_ = std::numeric_limits<size_t>::max() / shards_number;
+      for (const ShardsList& shards_list : old_index) {
+        for (const TaskInfo& task_info : shards_list) {
+          Put(std::get<ITERATOR>(task_info), std::get<HASH>(task_info));
+        }
+      }
+    }
+
+   private:
+    LockedQueue<T>* const queue_;
+    size_t chunk_size_ = {std::numeric_limits<size_t>::max()};
+    Vector<ShardsList> index_{1};
+    // |reverse_index_| is used to remove tasks from |index_| in O(1) when
+    // those are picked from the top of the |queue_|.
+    HashMap<const T*,
+            std::tuple<size_t, typename ShardsList::iterator>> reverse_index_;
+  };
 
   std::mutex pop_mutex_;
   std::condition_variable pop_condition_;
@@ -163,12 +186,7 @@ class LockedQueue {
   Atomic<ui64> size_ = {0};
   const ui64 capacity_ = UNLIMITED;
   Atomic<bool> closed_ = {false};
-  size_t chunk_size_ = {std::numeric_limits<size_t>::max()};
-  Vector<RangeList> index_{1};
-  // |reverse_index_| is used to remove tasks from |index_| in O(1) when
-  // those are picked from the top of the |queue_|.
-  HashMap<const T*,
-          std::tuple<size_t, typename RangeList::iterator>> reverse_index_;
+  Index index_;
 };
 
 }  // namespace base

--- a/src/base/queue_aggregator.h
+++ b/src/base/queue_aggregator.h
@@ -90,8 +90,9 @@ class QueueAggregator {
         UniqueLock lock(orders_mutex_);
 
         if (order_count_) {
-          orders_.push_back(std::move(queue->queue_.front()));
-          queue->queue_.pop();
+          auto task = queue->GetFromIndex(0u);
+          orders_.push_back(std::move(*task));
+          queue->queue_.erase(task);
           --queue->size_;
           --order_count_;
           lock.unlock();

--- a/src/base/queue_aggregator.h
+++ b/src/base/queue_aggregator.h
@@ -90,7 +90,7 @@ class QueueAggregator {
         UniqueLock lock(orders_mutex_);
 
         if (order_count_) {
-          auto task = queue->GetFromIndex(0u);
+          auto task = queue->index_.Get(0u);
           orders_.push_back(std::move(*task));
           queue->queue_.erase(task);
           --queue->size_;

--- a/src/base/thread_pool.cc
+++ b/src/base/thread_pool.cc
@@ -40,7 +40,7 @@ ThreadPool::Optional ThreadPool::Push(Closure&& task) {
 
 void ThreadPool::DoWork(const base::WorkerPool& pool) {
   while (!pool.IsShuttingDown()) {
-    TaskQueue::Optional&& task = tasks_.Pop(active_task_count_);
+    TaskQueue::Optional&& task = tasks_.Pop(&active_task_count_);
     if (!task) {
       break;
     }

--- a/src/base/worker_pool.h
+++ b/src/base/worker_pool.h
@@ -2,8 +2,7 @@
 
 #include <base/aliases.h>
 #include <base/file/pipe.h>
-
-#include STL(thread)
+#include <base/thread.h>
 
 namespace dist_clang {
 namespace base {
@@ -22,6 +21,10 @@ class WorkerPool {
   bool WaitUntilShutdown(const Seconds& duration) const;
 
   bool IsShuttingDown() const { return WaitUntilShutdown(ZERO_DURATION); }
+
+  size_t GetWorkersNumber() const {
+    return workers_.size();
+  }
 
  private:
   Vector<Thread> workers_;

--- a/src/base/worker_pool.h
+++ b/src/base/worker_pool.h
@@ -2,7 +2,8 @@
 
 #include <base/aliases.h>
 #include <base/file/pipe.h>
-#include <base/thread.h>
+
+#include STL(thread)
 
 namespace dist_clang {
 namespace base {
@@ -21,10 +22,6 @@ class WorkerPool {
   bool WaitUntilShutdown(const Seconds& duration) const;
 
   bool IsShuttingDown() const { return WaitUntilShutdown(ZERO_DURATION); }
-
-  size_t GetWorkersNumber() const {
-    return workers_.size();
-  }
 
  private:
   Vector<Thread> workers_;

--- a/src/daemon/compilation_daemon.cc
+++ b/src/daemon/compilation_daemon.cc
@@ -144,14 +144,6 @@ CompilationDaemon::CompilationDaemon(const Configuration& conf)
   }
 }
 
-HandledHash CompilationDaemon::GenerateHash(
-    const base::proto::Flags& flags, const HandledSource& code,
-    const ExtraFiles& extra_files) const {
-  const Version version(flags.compiler().version());
-  return cache::FileCache::Hash(code, extra_files,
-                                CommandLineForSimpleCache(flags), version);
-}
-
 bool CompilationDaemon::SetupCompiler(base::proto::Flags* flags,
                                       net::proto::Status* status) const {
   auto conf = this->conf();

--- a/src/daemon/compilation_daemon.cc
+++ b/src/daemon/compilation_daemon.cc
@@ -166,7 +166,6 @@ HandledHash CompilationDaemon::GenerateHash(
                                 CommandLineForSimpleCache(flags), version);
 }
 
-
 bool CompilationDaemon::SetupCompiler(base::proto::Flags* flags,
                                       net::proto::Status* status) const {
   auto conf = this->conf();

--- a/src/daemon/compilation_daemon.h
+++ b/src/daemon/compilation_daemon.h
@@ -20,10 +20,6 @@ class CompilationDaemon : public BaseDaemon {
  protected:
   explicit CompilationDaemon(const Configuration& conf);
 
-  cache::string::HandledHash GenerateHash(
-      const base::proto::Flags& flags, const cache::string::HandledSource& code,
-      const cache::ExtraFiles& extra_files) const;
-
   bool SetupCompiler(base::proto::Flags* flags,
                      net::proto::Status* status) const;
 

--- a/src/daemon/compilation_daemon.h
+++ b/src/daemon/compilation_daemon.h
@@ -20,6 +20,14 @@ class CompilationDaemon : public BaseDaemon {
  protected:
   explicit CompilationDaemon(const Configuration& conf);
 
+  ui64 GenerateIntegerHash(
+      const base::proto::Flags& flags, const cache::string::HandledSource& code,
+      const cache::ExtraFiles& extra_files) const;
+
+  cache::string::HandledHash GenerateHash(
+      const base::proto::Flags& flags, const cache::string::HandledSource& code,
+      const cache::ExtraFiles& extra_files) const;
+
   bool SetupCompiler(base::proto::Flags* flags,
                      net::proto::Status* status) const;
 

--- a/src/daemon/emitter.h
+++ b/src/daemon/emitter.h
@@ -24,11 +24,12 @@ class Emitter : public CompilationDaemon {
     MESSAGE = 1,
     SOURCE = 2,
     EXTRA_FILES = 3,
+    HASH = 4,
   };
 
   using Message = UniquePtr<base::proto::Local>;
   using Task = Tuple<net::ConnectionPtr, Message, cache::string::HandledSource,
-                     cache::ExtraFiles>;
+                     cache::ExtraFiles, ui64>;
   using Queue = base::LockedQueue<Task>;
   using QueueAggregator = base::QueueAggregator<Task>;
   using Optional = Queue::Optional;
@@ -47,6 +48,10 @@ class Emitter : public CompilationDaemon {
   void DoRemoteExecute(const base::WorkerPool&, ResolveFn resolver,
                        const ui32 distribution);
   void DoPoll(const base::WorkerPool&, Vector<ResolveFn> resolvers);
+
+  // Returns |true| if task was successfully populated.
+  // When |false| is returned - |task| may be moved from, so use with caution.
+  bool PopulateTask(Task* task);
 
   UniquePtr<Queue> all_tasks_, cache_tasks_, failed_tasks_;
   UniquePtr<QueueAggregator> local_tasks_;

--- a/src/daemon/emitter.h
+++ b/src/daemon/emitter.h
@@ -44,7 +44,8 @@ class Emitter : public CompilationDaemon {
 
   void DoCheckCache(const base::WorkerPool&);
   void DoLocalExecute(const base::WorkerPool&);
-  void DoRemoteExecute(const base::WorkerPool&, ResolveFn resolver);
+  void DoRemoteExecute(const base::WorkerPool&, ResolveFn resolver,
+                       const ui32 distribution);
   void DoPoll(const base::WorkerPool&, Vector<ResolveFn> resolvers);
 
   UniquePtr<Queue> all_tasks_, cache_tasks_, failed_tasks_;


### PR DESCRIPTION
Now Emitter finds out a hash of tasks for remote execution
and puts this info to LockedQueue. Also DoRemoteExecute now
has assigned distribution value that is used to pop appropriate
task from queue.