### PR TITLE
Little perf fix for ConstString

### DIFF
--- a/src/base/const_string.h
+++ b/src/base/const_string.h
@@ -102,6 +102,8 @@ class ConstString {
   InternalPtr CollapseRope();
   InternalPtr NullTerminate();
 
+  const char& at(const Internal* internal, size_t index) const;
+
   InternalPtr internals_ = InternalPtr(new Internal);
 
   size_t size_ = 0;


### PR DESCRIPTION
To access element by it's index introduced a private method 'at', which
requires a guarantee that |internals_| pointer wouldn't change
meanwhile.
This speeds up |ConstString::find| for about x10 as it makes *a lot* of
index lookups.